### PR TITLE
fix: pin foundry version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
+        with:
+          version: "nightly-de33b6af53005037b463318d2628b5cfcaf39916"
 
       - name: "Lint the contracts"
         run: "forge fmt"
@@ -41,6 +43,8 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
+        with:
+          version: "nightly-de33b6af53005037b463318d2628b5cfcaf39916"
 
       - name: "Build the contracts and print their size"
         run: "forge build --sizes"
@@ -64,6 +68,8 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
+        with:
+          version: "nightly-de33b6af53005037b463318d2628b5cfcaf39916"
 
       - name: "Show the Foundry config"
         run: "forge config"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ This repository contains the main smart contracts for Oval. It uses [Foundry](ht
 
 This repo also consists of a set of scripts used to profile the Oval gas usage. See [README](./scripts/README.md) that shows how to run these and [this](https://docs.oval.xyz/contract-architecture/gas-profiling) docs page that outlines the gas profiling finding.
 
+### Installing Foundry
+
+Tests in this repo work up to [Nightly (2024-03-02)](https://github.com/foundry-rs/foundry/releases/tag/nightly-de33b6af53005037b463318d2628b5cfcaf39916) Foundry version, so make sure to use it when installing:
+
+```
+foundryup -v nightly-de33b6af53005037b463318d2628b5cfcaf39916
+```
+
 ### Building Contracts
 
 ```


### PR DESCRIPTION
Foundry upgrades have changed how contract state is persisted between rolled forks and oval tests fail to work on the latest foundry versions. This fix pins foundry to the last known compatible [Nightly (2024-03-02)](https://github.com/foundry-rs/foundry/releases/tag/nightly-de33b6af53005037b463318d2628b5cfcaf39916) version.