### PR TITLE
feat: support chainlink round id

### DIFF
--- a/src/DiamondRootOval.sol
+++ b/src/DiamondRootOval.sol
@@ -15,9 +15,8 @@ abstract contract DiamondRootOval is IBaseController, IOval, IBaseOracleAdapter 
      * @notice Returns the latest data from the source.
      * @return answer The latest answer in 18 decimals.
      * @return updatedAt The timestamp of the answer.
-     * @return roundId The roundId of the answer.
      */
-    function getLatestSourceData() public view virtual returns (int256, uint256, uint256);
+    function getLatestSourceData() public view virtual returns (int256, uint256);
 
     /**
      * @notice Tries getting latest data as of requested timestamp. If this is not possible, returns the earliest data

--- a/src/DiamondRootOval.sol
+++ b/src/DiamondRootOval.sol
@@ -10,14 +10,14 @@ import {IOval} from "./interfaces/IOval.sol";
  * need. They are exposed here to simplify the inheritance structure of Oval contract system and to enable easier
  * composability and extensibility at the integration layer, enabling arbitrary combinations of sources and destinations.
  */
-
 abstract contract DiamondRootOval is IBaseController, IOval, IBaseOracleAdapter {
     /**
      * @notice Returns the latest data from the source.
      * @return answer The latest answer in 18 decimals.
      * @return updatedAt The timestamp of the answer.
+     * @return roundId The roundId of the answer.
      */
-    function getLatestSourceData() public view virtual returns (int256, uint256);
+    function getLatestSourceData() public view virtual returns (int256, uint256, uint256);
 
     /**
      * @notice Tries getting latest data as of requested timestamp. If this is not possible, returns the earliest data
@@ -26,16 +26,22 @@ abstract contract DiamondRootOval is IBaseController, IOval, IBaseOracleAdapter 
      * @param maxTraversal The maximum number of rounds to traverse when looking for historical data.
      * @return answer The answer as of requested timestamp, or earliest available data if not available, in 18 decimals.
      * @return updatedAt The timestamp of the answer.
+     * @return roundId The roundId of the answer.
      */
-    function tryLatestDataAt(uint256 timestamp, uint256 maxTraversal) public view virtual returns (int256, uint256);
+    function tryLatestDataAt(uint256 timestamp, uint256 maxTraversal)
+        public
+        view
+        virtual
+        returns (int256, uint256, uint256);
 
     /**
      * @notice Returns the latest data from the source. Depending on when Oval was last unlocked this might
      * return an slightly stale value to protect the OEV from being stolen by a front runner.
      * @return answer The latest answer in 18 decimals.
      * @return updatedAt The timestamp of the answer.
+     * @return roundId The roundId of the answer.
      */
-    function internalLatestData() public view virtual returns (int256, uint256);
+    function internalLatestData() public view virtual returns (int256, uint256, uint256);
 
     /**
      * @notice Snapshot the current source data. Is a no-op if the source does not require snapshotting.

--- a/src/DiamondRootOval.sol
+++ b/src/DiamondRootOval.sol
@@ -19,6 +19,15 @@ abstract contract DiamondRootOval is IBaseController, IOval, IBaseOracleAdapter 
     function getLatestSourceData() public view virtual returns (int256, uint256);
 
     /**
+     * @notice Returns the requested round data from the source.
+     * @dev If the source does not support rounds this would return uninitialized data.
+     * @param roundId The roundId to retrieve the round data for.
+     * @return answer Round answer in 18 decimals.
+     * @return updatedAt The timestamp of the answer.
+     */
+    function getSourceDataAtRound(uint256 roundId) public view virtual returns (int256, uint256);
+
+    /**
      * @notice Tries getting latest data as of requested timestamp. If this is not possible, returns the earliest data
      * available past the requested timestamp within provided traversal limitations.
      * @param timestamp The timestamp to try getting latest data at.
@@ -41,6 +50,16 @@ abstract contract DiamondRootOval is IBaseController, IOval, IBaseOracleAdapter 
      * @return roundId The roundId of the answer.
      */
     function internalLatestData() public view virtual returns (int256, uint256, uint256);
+
+    /**
+     * @notice Returns the requested round data from the source. Depending on when Oval was last unlocked this might
+     * also return uninitialized value to protect the OEV from being stolen by a front runner.
+     * @dev If the source does not support rounds this would always return uninitialized data.
+     * @param roundId The roundId to retrieve the round data for.
+     * @return answer Round answer in 18 decimals.
+     * @return updatedAt The timestamp of the answer.
+     */
+    function internalDataAtRound(uint256 roundId) public view virtual returns (int256, uint256);
 
     /**
      * @notice Snapshot the current source data. Is a no-op if the source does not require snapshotting.

--- a/src/Oval.sol
+++ b/src/Oval.sol
@@ -15,7 +15,6 @@ import {DiamondRootOval} from "./DiamondRootOval.sol";
  * contract that governs who can call unlockLatestValue.
  * @custom:security-contact bugs@umaproject.org
  */
-
 abstract contract Oval is DiamondRootOval {
     uint256 public lastUnlockTime; // Timestamp of the latest unlock to Oval.
 

--- a/src/Oval.sol
+++ b/src/Oval.sol
@@ -39,8 +39,9 @@ abstract contract Oval is DiamondRootOval {
      * @notice Returns latest data from source, governed by lockWindow controlling if returned data is stale.
      * @return answer The latest answer in 18 decimals.
      * @return timestamp The timestamp of the answer.
+     * @return roundId The roundId of the answer.
      */
-    function internalLatestData() public view override returns (int256, uint256) {
+    function internalLatestData() public view override returns (int256, uint256, uint256) {
         // Case work:
         //-> If unlockLatestValue has been called within lockWindow, then return most recent price as of unlockLatestValue call.
         //-> If unlockLatestValue has not been called in lockWindow, then return most recent value that is at least lockWindow old.

--- a/src/adapters/destination-adapters/BaseDestinationAdapter.sol
+++ b/src/adapters/destination-adapters/BaseDestinationAdapter.sol
@@ -8,7 +8,6 @@ import {DiamondRootOval} from "../../DiamondRootOval.sol";
  * implementation that consumers can connect with if they don't want to use an opinionated destination Adapter.
  *
  */
-
 abstract contract BaseDestinationAdapter is DiamondRootOval {
     uint8 public constant decimals = 18;
 
@@ -17,7 +16,7 @@ abstract contract BaseDestinationAdapter is DiamondRootOval {
      * @return answer The latest answer in 18 decimals.
      */
     function latestAnswer() public view returns (int256) {
-        (int256 answer,) = internalLatestData();
+        (int256 answer,,) = internalLatestData();
         return answer;
     }
 
@@ -26,7 +25,7 @@ abstract contract BaseDestinationAdapter is DiamondRootOval {
      * @return timestamp The timestamp of the most recent update.
      */
     function latestTimestamp() public view returns (uint256) {
-        (, uint256 timestamp) = internalLatestData();
+        (, uint256 timestamp,) = internalLatestData();
         return timestamp;
     }
 }

--- a/src/adapters/destination-adapters/ChainlinkDestinationAdapter.sol
+++ b/src/adapters/destination-adapters/ChainlinkDestinationAdapter.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.17;
 
+import {SafeCast} from "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+
 import {DecimalLib} from "../lib/DecimalLib.sol";
 import {IAggregatorV3} from "../../interfaces/chainlink/IAggregatorV3.sol";
 import {DiamondRootOval} from "../../DiamondRootOval.sol";
@@ -39,15 +41,22 @@ abstract contract ChainlinkDestinationAdapter is DiamondRootOval, IAggregatorV3 
 
     /**
      * @notice Returns the latest Round data.
-     * @return roundId The roundId of the latest answer.
+     * @return roundId The roundId of the latest answer (sources that do not support it hardcodes to 1).
      * @return answer The latest answer in the configured number of decimals.
      * @return startedAt The timestamp when the value was updated.
      * @return updatedAt The timestamp when the value was updated.
-     * @return answeredInRound The roundId of the round in which the answer was computed.
+     * @return answeredInRound The roundId of the round in which the answer was computed (sources that do not support it
+     * hardcodes to 1).
      */
     function latestRoundData() external view returns (uint80, int256, uint256, uint256, uint80) {
         (int256 answer, uint256 updatedAt, uint256 roundId) = internalLatestData();
-        return
-            (uint80(roundId), DecimalLib.convertDecimals(answer, 18, decimals), updatedAt, updatedAt, uint80(roundId));
+
+        return (
+            SafeCast.toUint80(roundId),
+            DecimalLib.convertDecimals(answer, 18, decimals),
+            updatedAt,
+            updatedAt,
+            SafeCast.toUint80(roundId)
+        );
     }
 }

--- a/src/adapters/destination-adapters/ChainlinkDestinationAdapter.sol
+++ b/src/adapters/destination-adapters/ChainlinkDestinationAdapter.sol
@@ -50,7 +50,7 @@ abstract contract ChainlinkDestinationAdapter is DiamondRootOval, IAggregatorV3 
      */
     function latestRoundData() external view returns (uint80, int256, uint256, uint256, uint80) {
         (int256 answer, uint256 updatedAt, uint256 _roundId) = internalLatestData();
-        roundId = SafeCast.toUint80(_roundId);
+        uint80 roundId = SafeCast.toUint80(_roundId);
         return (roundId, DecimalLib.convertDecimals(answer, 18, decimals), updatedAt, updatedAt, roundId);
     }
 }

--- a/src/adapters/destination-adapters/ChainlinkDestinationAdapter.sol
+++ b/src/adapters/destination-adapters/ChainlinkDestinationAdapter.sol
@@ -8,7 +8,6 @@ import {DiamondRootOval} from "../../DiamondRootOval.sol";
 /**
  * @title ChainlinkDestinationAdapter contract to expose Oval data via the standard Chainlink Aggregator interface.
  */
-
 abstract contract ChainlinkDestinationAdapter is DiamondRootOval, IAggregatorV3 {
     uint8 public immutable override decimals;
 
@@ -25,7 +24,7 @@ abstract contract ChainlinkDestinationAdapter is DiamondRootOval, IAggregatorV3 
      * @return answer The latest answer in the configured number of decimals.
      */
     function latestAnswer() public view override returns (int256) {
-        (int256 answer,) = internalLatestData();
+        (int256 answer,,) = internalLatestData();
         return DecimalLib.convertDecimals(answer, 18, decimals);
     }
 
@@ -34,21 +33,21 @@ abstract contract ChainlinkDestinationAdapter is DiamondRootOval, IAggregatorV3 
      * @return timestamp The timestamp of the latest answer.
      */
     function latestTimestamp() public view override returns (uint256) {
-        (, uint256 timestamp) = internalLatestData();
+        (, uint256 timestamp,) = internalLatestData();
         return timestamp;
     }
 
     /**
-     * @notice Returns an approximate form of the latest Round data. This does not implement the notion of "roundId" that
-     * the normal chainlink aggregator does and returns hardcoded values for those fields.
-     * @return roundId The roundId of the latest answer, hardcoded to 1.
+     * @notice Returns the latest Round data.
+     * @return roundId The roundId of the latest answer.
      * @return answer The latest answer in the configured number of decimals.
      * @return startedAt The timestamp when the value was updated.
      * @return updatedAt The timestamp when the value was updated.
-     * @return answeredInRound The roundId of the round in which the answer was computed, hardcoded to 1.
+     * @return answeredInRound The roundId of the round in which the answer was computed.
      */
     function latestRoundData() external view returns (uint80, int256, uint256, uint256, uint80) {
-        (int256 answer, uint256 updatedAt) = internalLatestData();
-        return (1, DecimalLib.convertDecimals(answer, 18, decimals), updatedAt, updatedAt, 1);
+        (int256 answer, uint256 updatedAt, uint256 roundId) = internalLatestData();
+        return
+            (uint80(roundId), DecimalLib.convertDecimals(answer, 18, decimals), updatedAt, updatedAt, uint80(roundId));
     }
 }

--- a/src/adapters/destination-adapters/ChainlinkDestinationAdapter.sol
+++ b/src/adapters/destination-adapters/ChainlinkDestinationAdapter.sol
@@ -53,4 +53,19 @@ abstract contract ChainlinkDestinationAdapter is DiamondRootOval, IAggregatorV3 
         uint80 roundId = SafeCast.toUint80(_roundId);
         return (roundId, DecimalLib.convertDecimals(answer, 18, decimals), updatedAt, updatedAt, roundId);
     }
+
+    /**
+     * @notice Returns the requested round data if available or uninitialized values then it is too recent.
+     * @dev If the source does not support round data, always returns uninitialized answer and timestamp values.
+     * @param _roundId The roundId to retrieve the round data for.
+     * @return roundId The roundId of the latest answer (same as requested roundId).
+     * @return answer The latest answer in the configured number of decimals.
+     * @return startedAt The timestamp when the value was updated.
+     * @return updatedAt The timestamp when the value was updated.
+     * @return answeredInRound The roundId of the round in which the answer was computed (same as requested roundId).
+     */
+    function getRoundData(uint80 _roundId) external view returns (uint80, int256, uint256, uint256, uint80) {
+        (int256 answer, uint256 updatedAt) = internalDataAtRound(_roundId);
+        return (_roundId, DecimalLib.convertDecimals(answer, 18, decimals), updatedAt, updatedAt, _roundId);
+    }
 }

--- a/src/adapters/destination-adapters/ChainlinkDestinationAdapter.sol
+++ b/src/adapters/destination-adapters/ChainlinkDestinationAdapter.sol
@@ -49,14 +49,8 @@ abstract contract ChainlinkDestinationAdapter is DiamondRootOval, IAggregatorV3 
      * hardcodes to 1).
      */
     function latestRoundData() external view returns (uint80, int256, uint256, uint256, uint80) {
-        (int256 answer, uint256 updatedAt, uint256 roundId) = internalLatestData();
-
-        return (
-            SafeCast.toUint80(roundId),
-            DecimalLib.convertDecimals(answer, 18, decimals),
-            updatedAt,
-            updatedAt,
-            SafeCast.toUint80(roundId)
-        );
+        (int256 answer, uint256 updatedAt, uint256 _roundId) = internalLatestData();
+        roundId = SafeCast.toUint80(_roundId);
+        return (roundId, DecimalLib.convertDecimals(answer, 18, decimals), updatedAt, updatedAt, roundId);
     }
 }

--- a/src/adapters/destination-adapters/ChronicleMedianDestinationAdapter.sol
+++ b/src/adapters/destination-adapters/ChronicleMedianDestinationAdapter.sol
@@ -19,7 +19,7 @@ abstract contract ChronicleMedianDestinationAdapter is IMedian, DiamondRootOval 
      * @return answer The latest answer in 18 decimals.
      */
     function read() public view override returns (uint256) {
-        (int256 answer,) = internalLatestData();
+        (int256 answer,,) = internalLatestData();
         require(answer > 0, "Median/invalid-price-feed");
         return uint256(answer);
     }
@@ -30,7 +30,7 @@ abstract contract ChronicleMedianDestinationAdapter is IMedian, DiamondRootOval 
      * @return valid True if the value returned is valid.
      */
     function peek() public view override returns (uint256, bool) {
-        (int256 answer,) = internalLatestData();
+        (int256 answer,,) = internalLatestData();
         return (uint256(answer), answer > 0);
     }
 
@@ -39,7 +39,7 @@ abstract contract ChronicleMedianDestinationAdapter is IMedian, DiamondRootOval 
      * @return timestamp The timestamp of the most recent update.
      */
     function age() public view override returns (uint32) {
-        (, uint256 timestamp) = internalLatestData();
+        (, uint256 timestamp,) = internalLatestData();
         return uint32(timestamp);
     }
 }

--- a/src/adapters/destination-adapters/OSMDestinationAdapter.sol
+++ b/src/adapters/destination-adapters/OSMDestinationAdapter.sol
@@ -19,7 +19,7 @@ abstract contract OSMDestinationAdapter is IOSM, DiamondRootOval {
     function read() public view override returns (bytes32) {
         // MakerDAO performs decimal conversion in collateral adapter contracts, so all oracle prices are expected to
         // have 18 decimals, the same as returned by the internalLatestData().answer.
-        (int256 answer,) = internalLatestData();
+        (int256 answer,,) = internalLatestData();
         return bytes32(uint256(answer));
     }
 
@@ -29,7 +29,7 @@ abstract contract OSMDestinationAdapter is IOSM, DiamondRootOval {
      * @return valid True if the value returned is valid.
      */
     function peek() public view override returns (bytes32, bool) {
-        (int256 answer,) = internalLatestData();
+        (int256 answer,,) = internalLatestData();
         // This might be required for MakerDAO when voiding Oracle sources.
         return (bytes32(uint256(answer)), answer > 0);
     }
@@ -39,7 +39,7 @@ abstract contract OSMDestinationAdapter is IOSM, DiamondRootOval {
      * @return timestamp The timestamp of the most recent update.
      */
     function zzz() public view override returns (uint64) {
-        (, uint256 timestamp) = internalLatestData();
+        (, uint256 timestamp,) = internalLatestData();
         return uint64(timestamp);
     }
 }

--- a/src/adapters/destination-adapters/PythDestinationAdapter.sol
+++ b/src/adapters/destination-adapters/PythDestinationAdapter.sol
@@ -51,7 +51,7 @@ contract PythDestinationAdapter is Ownable, IPyth {
         if (address(idToOval[id]) == address(0)) {
             return basePythProvider.getPriceUnsafe(id);
         }
-        (int256 answer, uint256 timestamp) = idToOval[id].internalLatestData();
+        (int256 answer, uint256 timestamp,) = idToOval[id].internalLatestData();
         return Price({
             price: SafeCast.toInt64(DecimalLib.convertDecimals(answer, 18, idToDecimal[id])),
             conf: 0,

--- a/src/adapters/destination-adapters/UniswapAnchoredViewDestinationAdapter.sol
+++ b/src/adapters/destination-adapters/UniswapAnchoredViewDestinationAdapter.sol
@@ -14,7 +14,6 @@ import {IOval} from "../../interfaces/IOval.sol";
  * that it uses to return the correct price for each cToken. This is needed as the UniswapAnchoredView interface is a
  * one to many relationship with cTokens, and so we need to be able to return the correct price for each cToken.
  */
-
 contract UniswapAnchoredViewDestinationAdapter is Ownable, IUniswapAnchoredView {
     mapping(address => address) public cTokenToOval;
     mapping(address => uint8) public cTokenToDecimal;
@@ -57,7 +56,7 @@ contract UniswapAnchoredViewDestinationAdapter is Ownable, IUniswapAnchoredView 
         if (cTokenToOval[cToken] == address(0)) {
             return uniswapAnchoredViewSource.getUnderlyingPrice(cToken);
         }
-        (int256 answer,) = IOval(cTokenToOval[cToken]).internalLatestData();
+        (int256 answer,,) = IOval(cTokenToOval[cToken]).internalLatestData();
         return DecimalLib.convertDecimals(uint256(answer), 18, cTokenToDecimal[cToken]);
     }
 

--- a/src/adapters/source-adapters/ChainlinkSourceAdapter.sol
+++ b/src/adapters/source-adapters/ChainlinkSourceAdapter.sol
@@ -56,11 +56,10 @@ abstract contract ChainlinkSourceAdapter is DiamondRootOval {
      * @notice Returns the latest data from the source.
      * @return answer The latest answer in 18 decimals.
      * @return updatedAt The timestamp of the answer.
-     * @return roundId The roundId of the answer.
      */
-    function getLatestSourceData() public view virtual override returns (int256, uint256, uint256) {
-        (uint80 roundId, int256 sourceAnswer,, uint256 updatedAt,) = CHAINLINK_SOURCE.latestRoundData();
-        return (DecimalLib.convertDecimals(sourceAnswer, SOURCE_DECIMALS, 18), updatedAt, roundId);
+    function getLatestSourceData() public view virtual override returns (int256, uint256) {
+        (, int256 sourceAnswer,, uint256 updatedAt,) = CHAINLINK_SOURCE.latestRoundData();
+        return (DecimalLib.convertDecimals(sourceAnswer, SOURCE_DECIMALS, 18), updatedAt);
     }
 
     // Tries getting latest data as of requested timestamp. If this is not possible, returns the earliest data available

--- a/src/adapters/source-adapters/ChainlinkSourceAdapter.sol
+++ b/src/adapters/source-adapters/ChainlinkSourceAdapter.sol
@@ -9,7 +9,6 @@ import {DiamondRootOval} from "../../DiamondRootOval.sol";
  * @title ChainlinkSourceAdapter contract to read data from Chainlink aggregator and standardize it for Oval.
  * @dev Can fetch information from Chainlink source at a desired timestamp for historic lookups.
  */
-
 abstract contract ChainlinkSourceAdapter is DiamondRootOval {
     IAggregatorV3Source public immutable CHAINLINK_SOURCE;
     uint8 private immutable SOURCE_DECIMALS;
@@ -35,16 +34,17 @@ abstract contract ChainlinkSourceAdapter is DiamondRootOval {
      * @param maxTraversal The maximum number of rounds to traverse when looking for historical data.
      * @return answer The answer as of requested timestamp, or earliest available data if not available, in 18 decimals.
      * @return updatedAt The timestamp of the answer.
+     * @return roundId The roundId of the answer.
      */
     function tryLatestDataAt(uint256 timestamp, uint256 maxTraversal)
         public
         view
         virtual
         override
-        returns (int256, uint256)
+        returns (int256, uint256, uint256)
     {
-        (int256 answer, uint256 updatedAt) = _tryLatestRoundDataAt(timestamp, maxTraversal);
-        return (DecimalLib.convertDecimals(answer, SOURCE_DECIMALS, 18), updatedAt);
+        (int256 answer, uint256 updatedAt, uint80 roundId) = _tryLatestRoundDataAt(timestamp, maxTraversal);
+        return (DecimalLib.convertDecimals(answer, SOURCE_DECIMALS, 18), updatedAt, roundId);
     }
 
     /**
@@ -56,27 +56,33 @@ abstract contract ChainlinkSourceAdapter is DiamondRootOval {
      * @notice Returns the latest data from the source.
      * @return answer The latest answer in 18 decimals.
      * @return updatedAt The timestamp of the answer.
+     * @return roundId The roundId of the answer.
      */
-    function getLatestSourceData() public view virtual override returns (int256, uint256) {
-        (, int256 sourceAnswer,, uint256 updatedAt,) = CHAINLINK_SOURCE.latestRoundData();
-        return (DecimalLib.convertDecimals(sourceAnswer, SOURCE_DECIMALS, 18), updatedAt);
+    function getLatestSourceData() public view virtual override returns (int256, uint256, uint256) {
+        (uint80 roundId, int256 sourceAnswer,, uint256 updatedAt,) = CHAINLINK_SOURCE.latestRoundData();
+        return (DecimalLib.convertDecimals(sourceAnswer, SOURCE_DECIMALS, 18), updatedAt, roundId);
     }
 
     // Tries getting latest data as of requested timestamp. If this is not possible, returns the earliest data available
     // past the requested timestamp considering the maxTraversal limitations.
-    function _tryLatestRoundDataAt(uint256 timestamp, uint256 maxTraversal) internal view returns (int256, uint256) {
+    function _tryLatestRoundDataAt(uint256 timestamp, uint256 maxTraversal)
+        internal
+        view
+        returns (int256, uint256, uint80)
+    {
         (uint80 roundId, int256 answer,, uint256 updatedAt,) = CHAINLINK_SOURCE.latestRoundData();
 
         // In the happy path there have been no source updates since requested time, so we can return the latest data.
         // We can use updatedAt property as it matches the block timestamp of the latest source transmission.
-        if (updatedAt <= timestamp) return (answer, updatedAt);
+        if (updatedAt <= timestamp) return (answer, updatedAt, roundId);
 
         // Attempt traversing historical round data backwards from roundId. This might still be newer or uninitialized.
-        (int256 historicalAnswer, uint256 historicalUpdatedAt) = _searchRoundDataAt(timestamp, roundId, maxTraversal);
+        (int256 historicalAnswer, uint256 historicalUpdatedAt, uint80 historicalRoundId) =
+            _searchRoundDataAt(timestamp, roundId, maxTraversal);
 
         // Validate returned data. If it is uninitialized we fallback to returning the current latest round data.
-        if (historicalUpdatedAt > 0) return (historicalAnswer, historicalUpdatedAt);
-        return (answer, updatedAt);
+        if (historicalUpdatedAt > 0) return (historicalAnswer, historicalUpdatedAt, historicalRoundId);
+        return (answer, updatedAt, roundId);
     }
 
     // Tries finding latest historical data (ignoring current roundId) not newer than requested timestamp. Might return
@@ -84,7 +90,7 @@ abstract contract ChainlinkSourceAdapter is DiamondRootOval {
     function _searchRoundDataAt(uint256 timestamp, uint80 targetRoundId, uint256 maxTraversal)
         internal
         view
-        returns (int256, uint256)
+        returns (int256, uint256, uint80)
     {
         uint80 roundId;
         int256 answer;
@@ -101,11 +107,11 @@ abstract contract ChainlinkSourceAdapter is DiamondRootOval {
             // aggregator that was not yet available on the aggregator proxy at the requested timestamp.
 
             (roundId, answer,, updatedAt,) = CHAINLINK_SOURCE.getRoundData(targetRoundId);
-            if (!(roundId == targetRoundId && updatedAt > 0)) return (0, 0);
-            if (updatedAt <= timestamp) return (answer, updatedAt);
+            if (!(roundId == targetRoundId && updatedAt > 0)) return (0, 0, 0);
+            if (updatedAt <= timestamp) return (answer, updatedAt, roundId);
             traversedRounds++;
         }
 
-        return (answer, updatedAt); // Did not find requested round. Return earliest round or uninitialized data.
+        return (answer, updatedAt, roundId); // Did not find requested round. Return earliest round or uninitialized data.
     }
 }

--- a/src/adapters/source-adapters/ChainlinkSourceAdapter.sol
+++ b/src/adapters/source-adapters/ChainlinkSourceAdapter.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.17;
 
+import {SafeCast} from "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+
 import {DecimalLib} from "../lib/DecimalLib.sol";
 import {IAggregatorV3Source} from "../../interfaces/chainlink/IAggregatorV3Source.sol";
 import {DiamondRootOval} from "../../DiamondRootOval.sol";
@@ -59,6 +61,18 @@ abstract contract ChainlinkSourceAdapter is DiamondRootOval {
      */
     function getLatestSourceData() public view virtual override returns (int256, uint256) {
         (, int256 sourceAnswer,, uint256 updatedAt,) = CHAINLINK_SOURCE.latestRoundData();
+        return (DecimalLib.convertDecimals(sourceAnswer, SOURCE_DECIMALS, 18), updatedAt);
+    }
+
+    /**
+     * @notice Returns the requested round data from the source.
+     * @dev If the source does not have the requested round it would return uninitialized data.
+     * @param roundId The roundId to retrieve the round data for.
+     * @return answer Round answer in 18 decimals.
+     * @return updatedAt The timestamp of the answer.
+     */
+    function getSourceDataAtRound(uint256 roundId) public view virtual override returns (int256, uint256) {
+        (, int256 sourceAnswer,, uint256 updatedAt,) = CHAINLINK_SOURCE.getRoundData(SafeCast.toUint80(roundId));
         return (DecimalLib.convertDecimals(sourceAnswer, SOURCE_DECIMALS, 18), updatedAt);
     }
 

--- a/src/adapters/source-adapters/ChronicleMedianSourceAdapter.sol
+++ b/src/adapters/source-adapters/ChronicleMedianSourceAdapter.sol
@@ -31,6 +31,16 @@ abstract contract ChronicleMedianSourceAdapter is SnapshotSource {
     }
 
     /**
+     * @notice Returns the requested round data from the source.
+     * @dev Chronicle Median does not support this and returns uninitialized data.
+     * @return answer Round answer in 18 decimals.
+     * @return updatedAt The timestamp of the answer.
+     */
+    function getSourceDataAtRound(uint256 /* roundId */ ) public view virtual override returns (int256, uint256) {
+        return (0, 0);
+    }
+
+    /**
      * @notice Tries getting latest data as of requested timestamp. If this is not possible, returns the earliest data
      * available past the requested timestamp within provided traversal limitations.
      * @dev Chronicle does not support historical lookups so this uses SnapshotSource to get historic data.
@@ -38,15 +48,16 @@ abstract contract ChronicleMedianSourceAdapter is SnapshotSource {
      * @param maxTraversal The maximum number of rounds to traverse when looking for historical data.
      * @return answer The answer as of requested timestamp, or earliest available data if not available, in 18 decimals.
      * @return updatedAt The timestamp of the answer.
+     * @return roundId The roundId of the answer (hardcoded to 1 as Chronicle Median does not support it).
      */
     function tryLatestDataAt(uint256 timestamp, uint256 maxTraversal)
         public
         view
         virtual
         override
-        returns (int256, uint256)
+        returns (int256, uint256, uint256)
     {
         Snapshot memory snapshot = _tryLatestDataAt(timestamp, maxTraversal);
-        return (snapshot.answer, snapshot.timestamp);
+        return (snapshot.answer, snapshot.timestamp, 1);
     }
 }

--- a/src/adapters/source-adapters/OSMSourceAdapter.sol
+++ b/src/adapters/source-adapters/OSMSourceAdapter.sol
@@ -32,6 +32,16 @@ abstract contract OSMSourceAdapter is SnapshotSource {
     }
 
     /**
+     * @notice Returns the requested round data from the source.
+     * @dev OSM does not support this and returns uninitialized data.
+     * @return answer Round answer in 18 decimals.
+     * @return updatedAt The timestamp of the answer.
+     */
+    function getSourceDataAtRound(uint256 /* roundId */ ) public view virtual override returns (int256, uint256) {
+        return (0, 0);
+    }
+
+    /**
      * @notice Tries getting latest data as of requested timestamp. If this is not possible, returns the earliest data
      * available past the requested timestamp within provided traversal limitations.
      * @dev OSM does not support historical lookups so this uses SnapshotSource to get historic data.
@@ -39,9 +49,15 @@ abstract contract OSMSourceAdapter is SnapshotSource {
      * @param maxTraversal The maximum number of rounds to traverse when looking for historical data.
      * @return answer The answer as of requested timestamp, or earliest available data if not available, in 18 decimals.
      * @return updatedAt The timestamp of the answer.
+     * @return roundId The roundId of the answer (hardcoded to 1 as OSM does not support it).
      */
-    function tryLatestDataAt(uint256 timestamp, uint256 maxTraversal) public view override returns (int256, uint256) {
+    function tryLatestDataAt(uint256 timestamp, uint256 maxTraversal)
+        public
+        view
+        override
+        returns (int256, uint256, uint256)
+    {
         Snapshot memory snapshot = _tryLatestDataAt(timestamp, maxTraversal);
-        return (snapshot.answer, snapshot.timestamp);
+        return (snapshot.answer, snapshot.timestamp, 1);
     }
 }

--- a/src/adapters/source-adapters/PythSourceAdapter.sol
+++ b/src/adapters/source-adapters/PythSourceAdapter.sol
@@ -32,6 +32,16 @@ abstract contract PythSourceAdapter is SnapshotSource {
     }
 
     /**
+     * @notice Returns the requested round data from the source.
+     * @dev Pyth does not support this and returns uninitialized data.
+     * @return answer Round answer in 18 decimals.
+     * @return updatedAt The timestamp of the answer.
+     */
+    function getSourceDataAtRound(uint256 /* roundId */ ) public view virtual override returns (int256, uint256) {
+        return (0, 0);
+    }
+
+    /**
      * @notice Tries getting latest data as of requested timestamp. If this is not possible, returns the earliest data
      * available past the requested timestamp within provided traversal limitations.
      * @dev Pyth does not support historical lookups so this uses SnapshotSource to get historic data.
@@ -39,16 +49,17 @@ abstract contract PythSourceAdapter is SnapshotSource {
      * @param maxTraversal The maximum number of rounds to traverse when looking for historical data.
      * @return answer The answer as of requested timestamp, or earliest available data if not available, in 18 decimals.
      * @return updatedAt The timestamp of the answer.
+     * @return roundId The roundId of the answer (hardcoded to 1 as Pyth does not support it).
      */
     function tryLatestDataAt(uint256 timestamp, uint256 maxTraversal)
         public
         view
         virtual
         override
-        returns (int256, uint256)
+        returns (int256, uint256, uint256)
     {
         Snapshot memory snapshot = _tryLatestDataAt(timestamp, maxTraversal);
-        return (snapshot.answer, snapshot.timestamp);
+        return (snapshot.answer, snapshot.timestamp, 1);
     }
 
     // Handle a per-price "expo" (decimal) value from pyth.

--- a/src/adapters/source-adapters/UniswapAnchoredViewSourceAdapter.sol
+++ b/src/adapters/source-adapters/UniswapAnchoredViewSourceAdapter.sol
@@ -55,12 +55,11 @@ abstract contract UniswapAnchoredViewSourceAdapter is SnapshotSource {
      * @notice Returns the latest data from the source.
      * @return answer The latest answer in 18 decimals.
      * @return updatedAt The timestamp of the answer.
-     * @return roundId The roundId of the answer.
      */
-    function getLatestSourceData() public view override returns (int256, uint256, uint256) {
-        (uint80 latestRoundId,,, uint256 latestTimestamp,) = aggregator.latestRoundData();
+    function getLatestSourceData() public view override returns (int256, uint256) {
+        (,,, uint256 latestTimestamp,) = aggregator.latestRoundData();
         int256 sourcePrice = int256(UNISWAP_ANCHORED_VIEW.getUnderlyingPrice(C_TOKEN));
-        return (DecimalLib.convertDecimals(sourcePrice, SOURCE_DECIMALS, 18), latestTimestamp, latestRoundId);
+        return (DecimalLib.convertDecimals(sourcePrice, SOURCE_DECIMALS, 18), latestTimestamp);
     }
 
     /**
@@ -71,7 +70,7 @@ abstract contract UniswapAnchoredViewSourceAdapter is SnapshotSource {
      * @param maxTraversal The maximum number of rounds to traverse when looking for historical data.
      * @return answer The answer as of requested timestamp, or earliest available data if not available, in 18 decimals.
      * @return updatedAt The timestamp of the answer.
-     * @return roundId The roundId of the answer.
+     * @return roundId The roundId of the answer (0 for UniswapAnchoredView as it does not support historical lookups).
      */
     function tryLatestDataAt(uint256 timestamp, uint256 maxTraversal)
         public
@@ -80,6 +79,6 @@ abstract contract UniswapAnchoredViewSourceAdapter is SnapshotSource {
         returns (int256, uint256, uint256)
     {
         Snapshot memory snapshot = _tryLatestDataAt(timestamp, maxTraversal);
-        return (DecimalLib.convertDecimals(snapshot.answer, SOURCE_DECIMALS, 18), snapshot.timestamp, snapshot.roundId);
+        return (DecimalLib.convertDecimals(snapshot.answer, SOURCE_DECIMALS, 18), snapshot.timestamp, 0);
     }
 }

--- a/src/adapters/source-adapters/UniswapAnchoredViewSourceAdapter.sol
+++ b/src/adapters/source-adapters/UniswapAnchoredViewSourceAdapter.sol
@@ -63,6 +63,16 @@ abstract contract UniswapAnchoredViewSourceAdapter is SnapshotSource {
     }
 
     /**
+     * @notice Returns the requested round data from the source.
+     * @dev UniswapAnchoredView does not support this and returns uninitialized data.
+     * @return answer Round answer in 18 decimals.
+     * @return updatedAt The timestamp of the answer.
+     */
+    function getSourceDataAtRound(uint256 /* roundId */ ) public view virtual override returns (int256, uint256) {
+        return (0, 0);
+    }
+
+    /**
      * @notice Tries getting latest data as of requested timestamp. If this is not possible, returns the earliest data
      * available past the requested timestamp within provided traversal limitations.
      * @dev UniswapAnchoredView does not support historical lookups so this uses SnapshotSource to get historic data.

--- a/src/adapters/source-adapters/UniswapAnchoredViewSourceAdapter.sol
+++ b/src/adapters/source-adapters/UniswapAnchoredViewSourceAdapter.sol
@@ -70,7 +70,7 @@ abstract contract UniswapAnchoredViewSourceAdapter is SnapshotSource {
      * @param maxTraversal The maximum number of rounds to traverse when looking for historical data.
      * @return answer The answer as of requested timestamp, or earliest available data if not available, in 18 decimals.
      * @return updatedAt The timestamp of the answer.
-     * @return roundId The roundId of the answer (0 for UniswapAnchoredView as it does not support historical lookups).
+     * @return roundId The roundId of the answer (hardcoded to 1 as UniswapAnchoredView does not support it).
      */
     function tryLatestDataAt(uint256 timestamp, uint256 maxTraversal)
         public
@@ -79,6 +79,6 @@ abstract contract UniswapAnchoredViewSourceAdapter is SnapshotSource {
         returns (int256, uint256, uint256)
     {
         Snapshot memory snapshot = _tryLatestDataAt(timestamp, maxTraversal);
-        return (DecimalLib.convertDecimals(snapshot.answer, SOURCE_DECIMALS, 18), snapshot.timestamp, 0);
+        return (DecimalLib.convertDecimals(snapshot.answer, SOURCE_DECIMALS, 18), snapshot.timestamp, 1);
     }
 }

--- a/src/controllers/BaseController.sol
+++ b/src/controllers/BaseController.sol
@@ -8,7 +8,6 @@ import {Oval} from "../Oval.sol";
  * @title BaseController providing the simplest possible controller logic to govern who can unlock Oval.
  * @dev Custom Controllers can be created to provide more granular control over who can unlock Oval.
  */
-
 abstract contract BaseController is Ownable, Oval {
     // these don't need to be public since they can be accessed via the accessor functions below.
     uint256 private lockWindow_ = 60; // The lockWindow in seconds.
@@ -46,12 +45,12 @@ abstract contract BaseController is Ownable, Oval {
      * @param newLockWindow The lockWindow to set.
      */
     function setLockWindow(uint256 newLockWindow) public onlyOwner {
-        (int256 currentAnswer, uint256 currentTimestamp) = internalLatestData();
+        (int256 currentAnswer, uint256 currentTimestamp,) = internalLatestData();
 
         lockWindow_ = newLockWindow;
 
         // Compare Oval results so that change in lock window does not change returned data.
-        (int256 newAnswer, uint256 newTimestamp) = internalLatestData();
+        (int256 newAnswer, uint256 newTimestamp,) = internalLatestData();
         require(currentAnswer == newAnswer && currentTimestamp == newTimestamp, "Must unlock first");
 
         emit LockWindowSet(newLockWindow);

--- a/src/controllers/ImmutableController.sol
+++ b/src/controllers/ImmutableController.sol
@@ -10,7 +10,6 @@ import {Oval} from "../Oval.sol";
  * 2. Because LOCK_WINDOW and MAX_TRAVERSAL are immutable, the read costs are much lower in the "hot" path (end
  *    oracle users).
  */
-
 abstract contract ImmutableController is Oval {
     uint256 private immutable LOCK_WINDOW; // The lockWindow in seconds.
     uint256 private immutable MAX_TRAVERSAL; // The maximum number of rounds to traverse when looking for historical data.

--- a/src/interfaces/IBaseOracleAdapter.sol
+++ b/src/interfaces/IBaseOracleAdapter.sol
@@ -7,5 +7,5 @@ interface IBaseOracleAdapter {
         view
         returns (int256 answer, uint256 timestamp, uint256 roundId);
 
-    function getLatestSourceData() external view returns (int256 answer, uint256 timestamp, uint256 roundId);
+    function getLatestSourceData() external view returns (int256 answer, uint256 timestamp);
 }

--- a/src/interfaces/IBaseOracleAdapter.sol
+++ b/src/interfaces/IBaseOracleAdapter.sol
@@ -5,7 +5,7 @@ interface IBaseOracleAdapter {
     function tryLatestDataAt(uint256 _timestamp, uint256 _maxTraversal)
         external
         view
-        returns (int256 answer, uint256 timestamp);
+        returns (int256 answer, uint256 timestamp, uint256 roundId);
 
-    function getLatestSourceData() external view returns (int256 answer, uint256 timestamp);
+    function getLatestSourceData() external view returns (int256 answer, uint256 timestamp, uint256 roundId);
 }

--- a/src/interfaces/IOval.sol
+++ b/src/interfaces/IOval.sol
@@ -4,5 +4,5 @@ pragma solidity 0.8.17;
 interface IOval {
     event LatestValueUnlocked(uint256 indexed timestamp);
 
-    function internalLatestData() external view returns (int256 answer, uint256 timestamp);
+    function internalLatestData() external view returns (int256 answer, uint256 timestamp, uint256 roundId);
 }

--- a/src/interfaces/chainlink/IAggregatorV3.sol
+++ b/src/interfaces/chainlink/IAggregatorV3.sol
@@ -13,6 +13,11 @@ interface IAggregatorV3 {
         view
         returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
 
+    function getRoundData(uint80 _roundId)
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+
     // Other Chainlink functions we don't need.
 
     // function latestRound() external view returns (uint256);
@@ -24,11 +29,6 @@ interface IAggregatorV3 {
     // function description() external view returns (string memory);
 
     // function version() external view returns (uint256);
-
-    // function getRoundData(uint80 _roundId)
-    //     external
-    //     view
-    //     returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
 
     // event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt);
 

--- a/test/fork/adapters/ChainlinkSourceAdapter.sol
+++ b/test/fork/adapters/ChainlinkSourceAdapter.sol
@@ -13,6 +13,8 @@ contract TestedSourceAdapter is ChainlinkSourceAdapter {
 
     function internalLatestData() public view override returns (int256, uint256, uint256) {}
 
+    function internalDataAtRound(uint256 roundId) public view override returns (int256, uint256) {}
+
     function canUnlock(address caller, uint256 cachedLatestTimestamp) public view virtual override returns (bool) {}
 
     function lockWindow() public view virtual override returns (uint256) {}

--- a/test/fork/adapters/ChronicleMedianSourceAdapter.sol
+++ b/test/fork/adapters/ChronicleMedianSourceAdapter.sol
@@ -8,7 +8,8 @@ import {IMedian} from "../../../src/interfaces/chronicle/IMedian.sol";
 
 contract TestedSourceAdapter is ChronicleMedianSourceAdapter {
     constructor(IMedian source) ChronicleMedianSourceAdapter(source) {}
-    function internalLatestData() public view override returns (int256, uint256) {}
+    function internalLatestData() public view override returns (int256, uint256, uint256) {}
+    function internalDataAtRound(uint256 roundId) public view override returns (int256, uint256) {}
     function canUnlock(address caller, uint256 cachedLatestTimestamp) public view virtual override returns (bool) {}
     function lockWindow() public view virtual override returns (uint256) {}
     function maxTraversal() public view virtual override returns (uint256) {}
@@ -52,9 +53,11 @@ contract ChronicleMedianSourceAdapterTest is CommonTest {
         assertTrue(latestChronicleTimestamp > targetTime);
 
         // Chronicle does not support historical lookups so this should still return latest data without snapshotting.
-        (int256 lookBackPrice, uint256 lookBackTimestamp) = sourceAdapter.tryLatestDataAt(targetTime, 100);
+        (int256 lookBackPrice, uint256 lookBackTimestamp, uint256 lookBackRoundId) =
+            sourceAdapter.tryLatestDataAt(targetTime, 100);
         assertTrue(int256(latestChronicleAnswer) == lookBackPrice);
         assertTrue(latestChronicleTimestamp == lookBackTimestamp);
+        assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
     }
 
     function testCorrectlyLooksBackThroughSnapshots() public {
@@ -62,18 +65,24 @@ contract ChronicleMedianSourceAdapterTest is CommonTest {
 
         for (uint256 i = 0; i < snapshotAnswers.length; i++) {
             // Lookback at exact snapshot timestamp should return the same answer and timestamp.
-            (int256 lookBackPrice, uint256 lookBackTimestamp) = sourceAdapter.tryLatestDataAt(snapshotTimestamps[i], 10);
+            (int256 lookBackPrice, uint256 lookBackTimestamp, uint256 lookBackRoundId) =
+                sourceAdapter.tryLatestDataAt(snapshotTimestamps[i], 10);
             assertTrue(int256(snapshotAnswers[i]) == lookBackPrice);
             assertTrue(snapshotTimestamps[i] == lookBackTimestamp);
+            assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
 
             // Source updates were more than 1 hour apart, so lookback 1 hour later should return the same answer.
-            (lookBackPrice, lookBackTimestamp) = sourceAdapter.tryLatestDataAt(snapshotTimestamps[i] + 3600, 10);
+            (lookBackPrice, lookBackTimestamp, lookBackRoundId) =
+                sourceAdapter.tryLatestDataAt(snapshotTimestamps[i] + 3600, 10);
             assertTrue(int256(snapshotAnswers[i]) == lookBackPrice);
             assertTrue(snapshotTimestamps[i] == lookBackTimestamp);
+            assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
 
             // Source updates were more than 1 hour apart, so lookback 1 hour earlier should return the previous answer,
             // except for the first snapshot which should return the same answer as it does not have earlier data.
-            (lookBackPrice, lookBackTimestamp) = sourceAdapter.tryLatestDataAt(snapshotTimestamps[i] - 3600, 10);
+            (lookBackPrice, lookBackTimestamp, lookBackRoundId) =
+                sourceAdapter.tryLatestDataAt(snapshotTimestamps[i] - 3600, 10);
+            assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
             if (i > 0) {
                 assertTrue(int256(snapshotAnswers[i - 1]) == lookBackPrice);
                 assertTrue(snapshotTimestamps[i - 1] == lookBackTimestamp);
@@ -90,11 +99,12 @@ contract ChronicleMedianSourceAdapterTest is CommonTest {
         // If we limit how far we can lookback the source adapter snapshot should correctly return the oldest data it
         // can find, up to that limit. When searching for the earliest possible snapshot while limiting maximum snapshot
         // traversal to 1 we should still get the latest data.
-        (int256 lookBackPrice, uint256 lookBackTimestamp) = sourceAdapter.tryLatestDataAt(0, 1);
+        (int256 lookBackPrice, uint256 lookBackTimestamp, uint256 lookBackRoundId) = sourceAdapter.tryLatestDataAt(0, 1);
         uint256 latestChronicleAnswer = chronicle.read();
         uint256 latestChronicleTimestamp = chronicle.age();
         assertTrue(int256(latestChronicleAnswer) == lookBackPrice);
         assertTrue(latestChronicleTimestamp == lookBackTimestamp);
+        assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
     }
 
     function _whitelistOnChronicle() internal {

--- a/test/fork/adapters/UnionSourceAdapter.sol
+++ b/test/fork/adapters/UnionSourceAdapter.sol
@@ -13,7 +13,9 @@ contract TestedSourceAdapter is UnionSourceAdapter {
         UnionSourceAdapter(chainlink, chronicle, pyth, pythPriceId)
     {}
 
-    function internalLatestData() public view override returns (int256, uint256) {}
+    function internalLatestData() public view override returns (int256, uint256, uint256) {}
+
+    function internalDataAtRound(uint256 roundId) public view override returns (int256, uint256) {}
 
     function canUnlock(address caller, uint256 cachedLatestTimestamp) public view virtual override returns (bool) {}
 
@@ -129,10 +131,11 @@ contract UnionSourceAdapterTest is CommonTest {
         assertTrue(latest.pyth.timestamp == historic.pyth.timestamp);
 
         // As no sources had updated we still expect historic union to match chainlink.
-        (int256 lookbackUnionAnswer, uint256 lookbackUnionTimestamp) =
+        (int256 lookbackUnionAnswer, uint256 lookbackUnionTimestamp, uint256 lookBackRoundId) =
             sourceAdapter.tryLatestDataAt(targetTimestamp, 10);
         assertTrue(lookbackUnionAnswer == historic.chainlink.answer);
         assertTrue(lookbackUnionTimestamp == historic.chainlink.timestamp);
+        assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
     }
 
     function testLookbackChronicle() public {
@@ -160,10 +163,11 @@ contract UnionSourceAdapterTest is CommonTest {
         assertTrue(latest.pyth.timestamp == historic.pyth.timestamp);
 
         // As no sources had updated we still expect historic union to match chronicle.
-        (int256 lookbackUnionAnswer, uint256 lookbackUnionTimestamp) =
+        (int256 lookbackUnionAnswer, uint256 lookbackUnionTimestamp, uint256 lookBackRoundId) =
             sourceAdapter.tryLatestDataAt(targetTimestamp, 10);
         assertTrue(lookbackUnionAnswer == historic.chronicle.answer);
         assertTrue(lookbackUnionTimestamp == historic.chronicle.timestamp);
+        assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
     }
 
     function testLookbackDropChronicle() public {
@@ -190,10 +194,11 @@ contract UnionSourceAdapterTest is CommonTest {
 
         // We cannot lookback to the historic timestamp as chronicle does not support historical lookups.
         // So we expect union lookback to fallback to chainlink.
-        (int256 lookbackUnionAnswer, uint256 lookbackUnionTimestamp) =
+        (int256 lookbackUnionAnswer, uint256 lookbackUnionTimestamp, uint256 lookBackRoundId) =
             sourceAdapter.tryLatestDataAt(targetTimestamp, 100);
         assertTrue(lookbackUnionAnswer == historic.chainlink.answer);
         assertTrue(lookbackUnionTimestamp == historic.chainlink.timestamp);
+        assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
     }
 
     function testLookbackPyth() public {
@@ -221,10 +226,11 @@ contract UnionSourceAdapterTest is CommonTest {
         assertTrue(latest.pyth.timestamp == historic.pyth.timestamp);
 
         // As no sources had updated we still expect historic union to match pyth.
-        (int256 lookbackUnionAnswer, uint256 lookbackUnionTimestamp) =
+        (int256 lookbackUnionAnswer, uint256 lookbackUnionTimestamp, uint256 lookBackRoundId) =
             sourceAdapter.tryLatestDataAt(targetTimestamp, 10);
         assertTrue(lookbackUnionAnswer == historic.pyth.answer);
         assertTrue(lookbackUnionTimestamp == historic.pyth.timestamp);
+        assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
     }
 
     function testLookbackDropPyth() public {
@@ -251,10 +257,11 @@ contract UnionSourceAdapterTest is CommonTest {
 
         // We cannot lookback to the historic timestamp as pyth does not support historical lookups.
         // So we expect union lookback to fallback to chainlink.
-        (int256 lookbackUnionAnswer, uint256 lookbackUnionTimestamp) =
+        (int256 lookbackUnionAnswer, uint256 lookbackUnionTimestamp, uint256 lookBackRoundId) =
             sourceAdapter.tryLatestDataAt(targetTimestamp, 100);
         assertTrue(lookbackUnionAnswer == historic.chainlink.answer);
         assertTrue(lookbackUnionTimestamp == historic.chainlink.timestamp);
+        assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
     }
 
     function _convertDecimalsWithExponent(int256 answer, int32 expo) internal pure returns (int256) {

--- a/test/fork/adapters/UniswapAnchoredViewSourceAdapter.sol
+++ b/test/fork/adapters/UniswapAnchoredViewSourceAdapter.sol
@@ -81,12 +81,14 @@ contract UniswapAnchoredViewSourceAdapterTest is CommonTest {
         // UniswapAnchoredView does not support historical lookups so this should still return latest data without snapshotting.
         uint256 latestUniswapAnchoredViewAnswer = uniswapAnchoredView.getUnderlyingPrice(cWBTC);
         uint256 latestAggregatorTimestamp = aggregator.latestTimestamp();
-        (int256 lookBackPrice, uint256 lookBackTimestamp) = sourceAdapter.tryLatestDataAt(targetTime, 100);
+        (int256 lookBackPrice, uint256 lookBackTimestamp, uint256 lookBackRoundId) =
+            sourceAdapter.tryLatestDataAt(targetTime, 100);
 
         // WBTC has 8 decimals, so source price feed is scaled at (36 - 8) = 28 decimals.
         uint256 standardizedAnswer = latestUniswapAnchoredViewAnswer / 10 ** (28 - 18);
         assertTrue(int256(standardizedAnswer) == lookBackPrice);
         assertTrue(latestAggregatorTimestamp == lookBackTimestamp);
+        assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
     }
 
     function testReturnsLatestSourceDataNoSnapshot() public {

--- a/test/fork/adapters/UniswapAnchoredViewSourceAdapter.sol
+++ b/test/fork/adapters/UniswapAnchoredViewSourceAdapter.sol
@@ -13,6 +13,7 @@ import {IUniswapAnchoredView} from "../../../src/interfaces/compound/IUniswapAnc
 contract TestedSourceAdapter is UniswapAnchoredViewSourceAdapter {
     constructor(IUniswapAnchoredView source, address cToken) UniswapAnchoredViewSourceAdapter(source, cToken) {}
     function internalLatestData() public view override returns (int256, uint256, uint256) {}
+    function internalDataAtRound(uint256 roundId) public view override returns (int256, uint256) {}
     function canUnlock(address caller, uint256 cachedLatestTimestamp) public view virtual override returns (bool) {}
     function lockWindow() public view virtual override returns (uint256) {}
     function maxTraversal() public view virtual override returns (uint256) {}

--- a/test/fork/adapters/UniswapAnchoredViewSourceAdapter.sol
+++ b/test/fork/adapters/UniswapAnchoredViewSourceAdapter.sol
@@ -78,9 +78,11 @@ contract UniswapAnchoredViewSourceAdapterTest is CommonTest {
         assertTrue(latestAggregatorTimestamp > targetTime);
 
         // UniswapAnchoredView does not support historical lookups so this should still return latest data without snapshotting.
-        (int256 lookBackPrice, uint256 lookBackTimestamp,) = sourceAdapter.tryLatestDataAt(targetTime, 100);
+        (int256 lookBackPrice, uint256 lookBackTimestamp, uint256 lookBackRoundId) =
+            sourceAdapter.tryLatestDataAt(targetTime, 100);
         assertTrue(int256(latestUniswapAnchoredViewAnswer) == lookBackPrice);
         assertTrue(latestAggregatorTimestamp == lookBackTimestamp);
+        assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
     }
 
     function testCorrectlyLooksBackThroughSnapshots() public {
@@ -88,19 +90,24 @@ contract UniswapAnchoredViewSourceAdapterTest is CommonTest {
 
         for (uint256 i = 0; i < snapshotAnswers.length; i++) {
             // Lookback at exact snapshot timestamp should return the same answer and timestamp.
-            (int256 lookBackPrice, uint256 lookBackTimestamp,) =
+            (int256 lookBackPrice, uint256 lookBackTimestamp, uint256 lookBackRoundId) =
                 sourceAdapter.tryLatestDataAt(snapshotTimestamps[i], 10);
             assertTrue(int256(snapshotAnswers[i]) == lookBackPrice);
             assertTrue(snapshotTimestamps[i] == lookBackTimestamp);
+            assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
 
             // Source updates were more than 30 minutes apart, so lookback 30 minutes later should return the same answer.
-            (lookBackPrice, lookBackTimestamp,) = sourceAdapter.tryLatestDataAt(snapshotTimestamps[i] + 1800, 10);
+            (lookBackPrice, lookBackTimestamp, lookBackRoundId) =
+                sourceAdapter.tryLatestDataAt(snapshotTimestamps[i] + 1800, 10);
             assertTrue(int256(snapshotAnswers[i]) == lookBackPrice);
             assertTrue(snapshotTimestamps[i] == lookBackTimestamp);
+            assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
 
             // Source updates were more than 30 minutes apart, so lookback 30 minutes earlier should return the previous answer,
             // except for the first snapshot which should return the same answer as it does not have earlier data.
-            (lookBackPrice, lookBackTimestamp,) = sourceAdapter.tryLatestDataAt(snapshotTimestamps[i] - 1800, 10);
+            (lookBackPrice, lookBackTimestamp, lookBackRoundId) =
+                sourceAdapter.tryLatestDataAt(snapshotTimestamps[i] - 1800, 10);
+            assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
             if (i > 0) {
                 assertTrue(int256(snapshotAnswers[i - 1]) == lookBackPrice);
                 assertTrue(snapshotTimestamps[i - 1] == lookBackTimestamp);
@@ -117,11 +124,12 @@ contract UniswapAnchoredViewSourceAdapterTest is CommonTest {
         // If we limit how far we can lookback the source adapter snapshot should correctly return the oldest data it
         // can find, up to that limit. When searching for the earliest possible snapshot while limiting maximum snapshot
         // traversal to 1 we should still get the latest data.
-        (int256 lookBackPrice, uint256 lookBackTimestamp,) = sourceAdapter.tryLatestDataAt(0, 1);
+        (int256 lookBackPrice, uint256 lookBackTimestamp, uint256 lookBackRoundId) = sourceAdapter.tryLatestDataAt(0, 1);
         uint256 latestUniswapAnchoredViewAnswer = uniswapAnchoredView.getUnderlyingPrice(cToken);
         uint256 latestAggregatorTimestamp = aggregator.latestTimestamp();
         assertTrue(int256(latestUniswapAnchoredViewAnswer) == lookBackPrice);
         assertTrue(latestAggregatorTimestamp == lookBackTimestamp);
+        assertTrue(lookBackRoundId == 1); // roundId not supported, hardcoded to 1.
     }
 
     function testUpgradeAggregator() public {

--- a/test/mocks/MockSnapshotSourceAdapter.sol
+++ b/test/mocks/MockSnapshotSourceAdapter.sol
@@ -25,10 +25,10 @@ abstract contract MockSnapshotSourceAdapter is SnapshotSource {
         view
         virtual
         override
-        returns (int256, uint256)
+        returns (int256, uint256, uint256)
     {
         SnapshotSource.Snapshot memory latestData = _tryLatestDataAt(timestamp, maxTraversal);
-        return (latestData.answer, latestData.timestamp);
+        return (latestData.answer, latestData.timestamp, 1);
     }
 
     function _latestSourceData() internal view returns (SourceData memory) {

--- a/test/mocks/MockSnapshotSourceAdapter.sol
+++ b/test/mocks/MockSnapshotSourceAdapter.sol
@@ -20,6 +20,10 @@ abstract contract MockSnapshotSourceAdapter is SnapshotSource {
         return (latestData.answer, latestData.timestamp);
     }
 
+    function getSourceDataAtRound(uint256 /* roundId */ ) public view virtual override returns (int256, uint256) {
+        return (0, 0);
+    }
+
     function tryLatestDataAt(uint256 timestamp, uint256 maxTraversal)
         public
         view

--- a/test/mocks/MockSourceAdapter.sol
+++ b/test/mocks/MockSourceAdapter.sol
@@ -41,7 +41,7 @@ abstract contract MockSourceAdapter is DiamondRootOval {
     }
 
     function getSourceDataAtRound(uint256 roundId) public view virtual override returns (int256, uint256) {
-        if (roundId == 0 || rounds.length <= roundId) return (0, 0);
+        if (roundId == 0 || rounds.length < roundId) return (0, 0);
         RoundData memory roundData = rounds[roundId - 1];
         return (roundData.answer, roundData.timestamp);
     }

--- a/test/mocks/MockSourceAdapter.sol
+++ b/test/mocks/MockSourceAdapter.sol
@@ -9,6 +9,7 @@ abstract contract MockSourceAdapter is DiamondRootOval {
     struct RoundData {
         int256 answer;
         uint256 timestamp;
+        uint256 roundId; // Assigned automatically, starting at 1.
     }
 
     RoundData[] public rounds;
@@ -20,7 +21,7 @@ abstract contract MockSourceAdapter is DiamondRootOval {
     function snapshotData() public override {}
 
     function publishRoundData(int256 answer, uint256 timestamp) public {
-        rounds.push(RoundData(answer, timestamp));
+        rounds.push(RoundData(answer, timestamp, rounds.length + 1));
     }
 
     function tryLatestDataAt(uint256 timestamp, uint256 maxTraversal)
@@ -28,10 +29,10 @@ abstract contract MockSourceAdapter is DiamondRootOval {
         view
         virtual
         override
-        returns (int256, uint256)
+        returns (int256, uint256, uint256)
     {
         RoundData memory latestData = _tryLatestDataAt(timestamp, maxTraversal);
-        return (latestData.answer, latestData.timestamp);
+        return (latestData.answer, latestData.timestamp, latestData.roundId);
     }
 
     function getLatestSourceData() public view virtual override returns (int256, uint256) {
@@ -41,7 +42,7 @@ abstract contract MockSourceAdapter is DiamondRootOval {
 
     function _latestRoundData() internal view returns (RoundData memory) {
         if (rounds.length > 0) return rounds[rounds.length - 1];
-        return RoundData(0, 0);
+        return RoundData(0, 0, 0);
     }
 
     function _tryLatestDataAt(uint256 timestamp, uint256 maxTraversal) internal view returns (RoundData memory) {
@@ -57,11 +58,11 @@ abstract contract MockSourceAdapter is DiamondRootOval {
     function _searchDataAt(uint256 timestamp, uint256 maxTraversal) internal view returns (RoundData memory) {
         RoundData memory roundData;
         uint256 traversedRounds = 0;
-        uint256 roundId = rounds.length;
+        uint256 roundIndex = rounds.length;
 
-        while (traversedRounds < maxTraversal && roundId > 0) {
-            roundId--;
-            roundData = rounds[roundId];
+        while (traversedRounds < maxTraversal && roundIndex > 0) {
+            roundIndex--;
+            roundData = rounds[roundIndex];
             if (roundData.timestamp <= timestamp) return roundData;
             traversedRounds++;
         }

--- a/test/mocks/MockSourceAdapter.sol
+++ b/test/mocks/MockSourceAdapter.sol
@@ -40,6 +40,12 @@ abstract contract MockSourceAdapter is DiamondRootOval {
         return (latestData.answer, latestData.timestamp);
     }
 
+    function getSourceDataAtRound(uint256 roundId) public view virtual override returns (int256, uint256) {
+        if (roundId == 0 || rounds.length <= roundId) return (0, 0);
+        RoundData memory roundData = rounds[roundId - 1];
+        return (roundData.answer, roundData.timestamp);
+    }
+
     function _latestRoundData() internal view returns (RoundData memory) {
         if (rounds.length > 0) return rounds[rounds.length - 1];
         return RoundData(0, 0, 0);

--- a/test/unit/Oval.ChainlinkDestinationAdapter.sol
+++ b/test/unit/Oval.ChainlinkDestinationAdapter.sol
@@ -37,7 +37,7 @@ contract OvalChainlinkDestinationAdapter is CommonTest {
     }
 
     function verifyOvalMatchesOval() public {
-        (int256 latestAnswer, uint256 latestTimestamp) = oval.internalLatestData();
+        (int256 latestAnswer, uint256 latestTimestamp,) = oval.internalLatestData();
         assertTrue(
             latestAnswer / internalDecimalsToSourceDecimals == oval.latestAnswer()
                 && latestTimestamp == oval.latestTimestamp()

--- a/test/unit/Oval.ChainlinkDestinationAdapter.sol
+++ b/test/unit/Oval.ChainlinkDestinationAdapter.sol
@@ -72,10 +72,10 @@ contract OvalChainlinkDestinationAdapter is CommonTest {
             oval.latestRoundData();
 
         // Check that Oval return the correct values scaled to the source oracle decimals.
-        assertTrue(roundId == 1);
+        assertTrue(roundId == 2);
         assertTrue(answer == newAnswer / internalDecimalsToSourceDecimals);
         assertTrue(startedAt == newTimestamp);
         assertTrue(updatedAt == newTimestamp);
-        assertTrue(answeredInRound == 1);
+        assertTrue(answeredInRound == 2);
     }
 }

--- a/test/unit/Oval.ChainlinkDestinationAdapter.sol
+++ b/test/unit/Oval.ChainlinkDestinationAdapter.sol
@@ -77,4 +77,31 @@ contract OvalChainlinkDestinationAdapter is CommonTest {
         oval.unlockLatestValue();
         verifyOvalMatchesOval();
     }
+
+    function testReturnUninitializedRoundData() public {
+        // Advance time to within the lock window and update the source.
+        uint256 beforeLockWindow = block.timestamp + oval.lockWindow() - 1;
+        vm.warp(beforeLockWindow);
+        publishRoundData(newAnswer, beforeLockWindow);
+
+        // Before updating, uninitialized values would be returned.
+        (int256 latestAnswer, uint256 latestTimestamp) = oval.internalDataAtRound(latestPublishedRound);
+        assertTrue(latestAnswer == 0 && latestTimestamp == 0);
+    }
+
+    function testReturnUnlockedRoundData() public {
+        // Advance time to within the lock window and update the source.
+        uint256 beforeLockWindow = block.timestamp + oval.lockWindow() - 1;
+        vm.warp(beforeLockWindow);
+        publishRoundData(newAnswer, beforeLockWindow);
+
+        // Unlock new round values.
+        vm.prank(permissionedUnlocker);
+        oval.unlockLatestValue();
+        verifyOvalMatchesOval();
+
+        // After unlock we should return the new values.
+        (int256 latestAnswer, uint256 latestTimestamp) = oval.internalDataAtRound(latestPublishedRound);
+        assertTrue(latestAnswer == newAnswer && latestTimestamp == beforeLockWindow);
+    }
 }

--- a/test/unit/Oval.ChainlinkDestinationAdapter.sol
+++ b/test/unit/Oval.ChainlinkDestinationAdapter.sol
@@ -72,10 +72,10 @@ contract OvalChainlinkDestinationAdapter is CommonTest {
             oval.latestRoundData();
 
         // Check that Oval return the correct values scaled to the source oracle decimals.
-        assertTrue(roundId == 2);
+        assertTrue(roundId == 2); // We published twice and roundId starts at 1.
         assertTrue(answer == newAnswer / internalDecimalsToSourceDecimals);
         assertTrue(startedAt == newTimestamp);
         assertTrue(updatedAt == newTimestamp);
-        assertTrue(answeredInRound == 2);
+        assertTrue(answeredInRound == 2); // We published twice and roundId starts at 1.
     }
 }

--- a/test/unit/Oval.ChronicleMedianDestinationAdapter.sol
+++ b/test/unit/Oval.ChronicleMedianDestinationAdapter.sol
@@ -42,7 +42,7 @@ contract OvalChronicleMedianDestinationAdapter is CommonTest {
     }
 
     function verifyOvalOracleMatchesOvalOracle() public {
-        (int256 latestAnswer, uint256 latestTimestamp) = oval.internalLatestData();
+        (int256 latestAnswer, uint256 latestTimestamp,) = oval.internalLatestData();
 
         (, bool sourceValid) = oval.peek();
         assertTrue(sourceValid);

--- a/test/unit/Oval.OSMDestinationAdapter.sol
+++ b/test/unit/Oval.OSMDestinationAdapter.sol
@@ -33,7 +33,7 @@ contract OvalChronicleMedianDestinationAdapter is CommonTest {
     }
 
     function verifyOvalOracleMatchesOvalOracle() public {
-        (int256 latestAnswer, uint256 latestTimestamp) = oval.internalLatestData();
+        (int256 latestAnswer, uint256 latestTimestamp,) = oval.internalLatestData();
 
         (, bool sourceValid) = oval.peek();
         assertTrue(sourceValid);

--- a/test/unit/Oval.PythDestinationAdapter.sol
+++ b/test/unit/Oval.PythDestinationAdapter.sol
@@ -24,6 +24,7 @@ contract OvalChronicleMedianDestinationAdapter is CommonTest {
 
     int256 newAnswer = 1900 * 1e18;
     uint256 newTimestamp = initialTimestamp + 1;
+    uint256 roundId = 1; // Pyth does not support roundId and has it hardcoded to 1.
 
     bytes32 testId = keccak256("testId");
     uint8 testDecimals = 8;
@@ -49,7 +50,9 @@ contract OvalChronicleMedianDestinationAdapter is CommonTest {
     function testGetPriceUnsafe() public {
         destinationAdapter.setOval(testId, testDecimals, testValidTimePeriod, IOval(OvalAddress));
         vm.mockCall(
-            OvalAddress, abi.encodeWithSelector(IOval.internalLatestData.selector), abi.encode(newAnswer, newTimestamp)
+            OvalAddress,
+            abi.encodeWithSelector(IOval.internalLatestData.selector),
+            abi.encode(newAnswer, newTimestamp, roundId)
         );
 
         IPyth.Price memory price = destinationAdapter.getPriceUnsafe(testId);
@@ -63,7 +66,9 @@ contract OvalChronicleMedianDestinationAdapter is CommonTest {
         destinationAdapter.setOval(testId, testDecimals, testValidTimePeriod, IOval(OvalAddress));
         uint256 timestamp = block.timestamp;
         vm.mockCall(
-            OvalAddress, abi.encodeWithSelector(IOval.internalLatestData.selector), abi.encode(newAnswer, timestamp)
+            OvalAddress,
+            abi.encodeWithSelector(IOval.internalLatestData.selector),
+            abi.encode(newAnswer, timestamp, roundId)
         );
 
         IPyth.Price memory price = destinationAdapter.getPrice(testId);
@@ -78,7 +83,9 @@ contract OvalChronicleMedianDestinationAdapter is CommonTest {
         vm.warp(newTimestamp + testValidTimePeriod + 1); // Warp to after the valid time period.
 
         vm.mockCall(
-            OvalAddress, abi.encodeWithSelector(IOval.internalLatestData.selector), abi.encode(newAnswer, newTimestamp)
+            OvalAddress,
+            abi.encodeWithSelector(IOval.internalLatestData.selector),
+            abi.encode(newAnswer, newTimestamp, roundId)
         );
 
         vm.expectRevert("Not within valid window");
@@ -90,7 +97,9 @@ contract OvalChronicleMedianDestinationAdapter is CommonTest {
         vm.warp(newTimestamp - 1); // Warp to before publish time.
 
         vm.mockCall(
-            OvalAddress, abi.encodeWithSelector(IOval.internalLatestData.selector), abi.encode(newAnswer, newTimestamp)
+            OvalAddress,
+            abi.encodeWithSelector(IOval.internalLatestData.selector),
+            abi.encode(newAnswer, newTimestamp, roundId)
         );
 
         IPyth.Price memory price = destinationAdapter.getPrice(testId);

--- a/test/unit/Oval.UniswapAnchoredViewDestinationAdapter.sol
+++ b/test/unit/Oval.UniswapAnchoredViewDestinationAdapter.sol
@@ -11,6 +11,7 @@ import {CommonTest} from "../Common.sol";
 contract OvalUniswapAnchoredViewDestinationAdapter is CommonTest {
     int256 newAnswer = 1900 * 1e18;
     uint256 newTimestamp = 1690000000;
+    uint256 roundId = 1; // UniswapAnchoredView does not support roundId and has it hardcoded to 1.
 
     int256 internalDecimalsToSourceDecimals = 1e10;
 
@@ -75,7 +76,7 @@ contract OvalUniswapAnchoredViewDestinationAdapter is CommonTest {
         vm.mockCall(
             OvalAddress,
             abi.encodeWithSelector(IOval.internalLatestData.selector),
-            abi.encode(newAnswer, newTimestamp, 1)
+            abi.encode(newAnswer, newTimestamp, roundId)
         );
         uint256 underlyingPrice = destinationAdapter.getUnderlyingPrice(cTokenAddress);
 

--- a/test/unit/Oval.UniswapAnchoredViewDestinationAdapter.sol
+++ b/test/unit/Oval.UniswapAnchoredViewDestinationAdapter.sol
@@ -73,7 +73,9 @@ contract OvalUniswapAnchoredViewDestinationAdapter is CommonTest {
         destinationAdapter.setOval(cTokenAddress, OvalAddress);
 
         vm.mockCall(
-            OvalAddress, abi.encodeWithSelector(IOval.internalLatestData.selector), abi.encode(newAnswer, newTimestamp)
+            OvalAddress,
+            abi.encodeWithSelector(IOval.internalLatestData.selector),
+            abi.encode(newAnswer, newTimestamp, 1)
         );
         uint256 underlyingPrice = destinationAdapter.getUnderlyingPrice(cTokenAddress);
 

--- a/test/unit/Oval.UnlockLatestValue.sol
+++ b/test/unit/Oval.UnlockLatestValue.sol
@@ -32,7 +32,7 @@ contract OvalUnlockLatestValue is CommonTest {
     }
 
     function verifyOvalMatchesOval() public {
-        (int256 latestAnswer, uint256 latestTimestamp) = oval.internalLatestData();
+        (int256 latestAnswer, uint256 latestTimestamp,) = oval.internalLatestData();
         assertTrue(latestAnswer == oval.latestAnswer() && latestTimestamp == oval.latestTimestamp());
     }
 
@@ -67,7 +67,7 @@ contract OvalUnlockLatestValue is CommonTest {
         vm.prank(permissionedUnlocker);
         oval.unlockLatestValue();
         verifyOvalMatchesOval();
-        (int256 latestAnswer, uint256 latestTimestamp) = oval.internalLatestData();
+        (int256 latestAnswer, uint256 latestTimestamp,) = oval.internalLatestData();
         assertTrue(latestAnswer == newAnswer && latestTimestamp == newTimestamp);
 
         // Advance time. Add a diff to the source adapter and verify that it is applied.
@@ -88,7 +88,7 @@ contract OvalUnlockLatestValue is CommonTest {
         vm.prank(random);
         oval.unlockLatestValue();
 
-        (int256 latestAnswer, uint256 latestTimestamp) = oval.internalLatestData();
+        (int256 latestAnswer, uint256 latestTimestamp,) = oval.internalLatestData();
         assertTrue(latestAnswer == initialPrice && latestTimestamp == initialTimestamp);
     }
 
@@ -101,7 +101,7 @@ contract OvalUnlockLatestValue is CommonTest {
         oval.publishRoundData(newAnswer, beforeLockWindow);
 
         // Before updating, initial values from cache would be returned.
-        (int256 latestAnswer, uint256 latestTimestamp) = oval.internalLatestData();
+        (int256 latestAnswer, uint256 latestTimestamp,) = oval.internalLatestData();
         assertTrue(latestAnswer == initialPrice && latestTimestamp == initialTimestamp);
 
         // After updating we should return the new values.
@@ -119,14 +119,14 @@ contract OvalUnlockLatestValue is CommonTest {
         oval.publishRoundData(newAnswer, beforeOEVLockWindow); // Update the source.
 
         // Within original lock window (after OEV unlock), initial values from cache would be returned.
-        (int256 latestAnswer, uint256 latestTimestamp) = oval.internalLatestData();
+        (int256 latestAnswer, uint256 latestTimestamp,) = oval.internalLatestData();
         assertTrue(latestAnswer == initialPrice && latestTimestamp == initialTimestamp, "1");
 
         // Advancing time past the original lock window but before new lock window since source update
         // should not yet pass through source values.
         uint256 pastOEVLockWindow = beforeOEVLockWindow + 2;
         vm.warp(pastOEVLockWindow);
-        (latestAnswer, latestTimestamp) = oval.internalLatestData();
+        (latestAnswer, latestTimestamp,) = oval.internalLatestData();
         assertTrue(latestAnswer == initialPrice && latestTimestamp == initialTimestamp);
 
         // Advancing time past the new lock window should pass through source values.
@@ -144,7 +144,7 @@ contract OvalUnlockLatestValue is CommonTest {
         oval.publishRoundData(newAnswer, beforeLockWindow);
 
         // Before updating, initial values from cache would be returned.
-        (int256 latestAnswer, uint256 latestTimestamp) = oval.internalLatestData();
+        (int256 latestAnswer, uint256 latestTimestamp,) = oval.internalLatestData();
         assertTrue(latestAnswer == initialPrice && latestTimestamp == initialTimestamp);
 
         // Sync and verify updated values.
@@ -157,7 +157,7 @@ contract OvalUnlockLatestValue is CommonTest {
         oval.publishRoundData(nextNewAnswer, nextBeforeLockWindow);
 
         // Within lock window, values from previous update would be returned.
-        (latestAnswer, latestTimestamp) = oval.internalLatestData();
+        (latestAnswer, latestTimestamp,) = oval.internalLatestData();
         assertTrue(latestAnswer == newAnswer && latestTimestamp == beforeLockWindow);
     }
 }

--- a/test/unit/Oval.UnlockLatestValue.sol
+++ b/test/unit/Oval.UnlockLatestValue.sol
@@ -20,6 +20,8 @@ contract OvalUnlockLatestValue is CommonTest {
 
     TestOval oval;
 
+    uint256 latestPublishedRound;
+
     function setUp() public {
         vm.warp(initialTimestamp);
 
@@ -28,12 +30,18 @@ contract OvalUnlockLatestValue is CommonTest {
         oval.setUnlocker(permissionedUnlocker, true);
         vm.stopPrank();
 
-        oval.publishRoundData(initialPrice, initialTimestamp);
+        publishRoundData(initialPrice, initialTimestamp);
+    }
+
+    function publishRoundData(int256 answer, uint256 timestamp) public {
+        oval.publishRoundData(answer, timestamp);
+        ++latestPublishedRound;
     }
 
     function verifyOvalMatchesOval() public {
-        (int256 latestAnswer, uint256 latestTimestamp,) = oval.internalLatestData();
+        (int256 latestAnswer, uint256 latestTimestamp, uint256 latestRoundId) = oval.internalLatestData();
         assertTrue(latestAnswer == oval.latestAnswer() && latestTimestamp == oval.latestTimestamp());
+        assertTrue(latestRoundId == latestPublishedRound);
     }
 
     function syncOvalWithOval() public {
@@ -61,7 +69,7 @@ contract OvalUnlockLatestValue is CommonTest {
     function testUnlockerCanUnlockLatestValue() public {
         syncOvalWithOval();
 
-        oval.publishRoundData(newAnswer, newTimestamp);
+        publishRoundData(newAnswer, newTimestamp);
         vm.warp(newTimestamp);
 
         vm.prank(permissionedUnlocker);
@@ -72,7 +80,7 @@ contract OvalUnlockLatestValue is CommonTest {
 
         // Advance time. Add a diff to the source adapter and verify that it is applied.
         vm.warp(newTimestamp + 2);
-        oval.publishRoundData(newAnswer + 1, newTimestamp + 2);
+        publishRoundData(newAnswer + 1, newTimestamp + 2);
         vm.prank(permissionedUnlocker);
         oval.unlockLatestValue();
         verifyOvalMatchesOval();
@@ -81,15 +89,16 @@ contract OvalUnlockLatestValue is CommonTest {
     function testNonUnlockerCannotUnlockLatestValue() public {
         syncOvalWithOval();
 
-        oval.publishRoundData(newAnswer, newTimestamp);
+        publishRoundData(newAnswer, newTimestamp);
         vm.warp(newTimestamp);
 
         vm.expectRevert("Controller blocked: canUnlock");
         vm.prank(random);
         oval.unlockLatestValue();
 
-        (int256 latestAnswer, uint256 latestTimestamp,) = oval.internalLatestData();
+        (int256 latestAnswer, uint256 latestTimestamp, uint256 latestRoundId) = oval.internalLatestData();
         assertTrue(latestAnswer == initialPrice && latestTimestamp == initialTimestamp);
+        assertTrue(latestRoundId == latestPublishedRound - 1);
     }
 
     function testUpdatesWithinLockWindow() public {
@@ -98,11 +107,12 @@ contract OvalUnlockLatestValue is CommonTest {
         // Advance time to within the lock window and update the source.
         uint256 beforeLockWindow = block.timestamp + oval.lockWindow() - 1;
         vm.warp(beforeLockWindow);
-        oval.publishRoundData(newAnswer, beforeLockWindow);
+        publishRoundData(newAnswer, beforeLockWindow);
 
         // Before updating, initial values from cache would be returned.
-        (int256 latestAnswer, uint256 latestTimestamp,) = oval.internalLatestData();
+        (int256 latestAnswer, uint256 latestTimestamp, uint256 latestRoundId) = oval.internalLatestData();
         assertTrue(latestAnswer == initialPrice && latestTimestamp == initialTimestamp);
+        assertTrue(latestRoundId == latestPublishedRound - 1);
 
         // After updating we should return the new values.
         vm.prank(permissionedUnlocker);
@@ -116,18 +126,20 @@ contract OvalUnlockLatestValue is CommonTest {
 
         uint256 beforeOEVLockWindow = unlockTimestamp + 59; // Default lock window is 10 minutes.
         vm.warp(beforeOEVLockWindow); // Advance before the end of the lock window.
-        oval.publishRoundData(newAnswer, beforeOEVLockWindow); // Update the source.
+        publishRoundData(newAnswer, beforeOEVLockWindow); // Update the source.
 
         // Within original lock window (after OEV unlock), initial values from cache would be returned.
-        (int256 latestAnswer, uint256 latestTimestamp,) = oval.internalLatestData();
+        (int256 latestAnswer, uint256 latestTimestamp, uint256 latestRoundId) = oval.internalLatestData();
         assertTrue(latestAnswer == initialPrice && latestTimestamp == initialTimestamp, "1");
+        assertTrue(latestRoundId == latestPublishedRound - 1);
 
         // Advancing time past the original lock window but before new lock window since source update
         // should not yet pass through source values.
         uint256 pastOEVLockWindow = beforeOEVLockWindow + 2;
         vm.warp(pastOEVLockWindow);
-        (latestAnswer, latestTimestamp,) = oval.internalLatestData();
+        (latestAnswer, latestTimestamp, latestRoundId) = oval.internalLatestData();
         assertTrue(latestAnswer == initialPrice && latestTimestamp == initialTimestamp);
+        assertTrue(latestRoundId == latestPublishedRound - 1);
 
         // Advancing time past the new lock window should pass through source values.
         uint256 pastSourceLockWindow = beforeOEVLockWindow + 69;
@@ -141,11 +153,12 @@ contract OvalUnlockLatestValue is CommonTest {
         // Advance time to within the lock window and update the source.
         uint256 beforeLockWindow = block.timestamp + oval.lockWindow() - 1;
         vm.warp(beforeLockWindow);
-        oval.publishRoundData(newAnswer, beforeLockWindow);
+        publishRoundData(newAnswer, beforeLockWindow);
 
         // Before updating, initial values from cache would be returned.
-        (int256 latestAnswer, uint256 latestTimestamp,) = oval.internalLatestData();
+        (int256 latestAnswer, uint256 latestTimestamp, uint256 latestRoundId) = oval.internalLatestData();
         assertTrue(latestAnswer == initialPrice && latestTimestamp == initialTimestamp);
+        assertTrue(latestRoundId == latestPublishedRound - 1);
 
         // Sync and verify updated values.
         syncOvalWithOval();
@@ -154,10 +167,11 @@ contract OvalUnlockLatestValue is CommonTest {
         uint256 nextBeforeLockWindow = block.timestamp + oval.lockWindow() - 1;
         vm.warp(nextBeforeLockWindow);
         int256 nextNewAnswer = newAnswer + 1e18;
-        oval.publishRoundData(nextNewAnswer, nextBeforeLockWindow);
+        publishRoundData(nextNewAnswer, nextBeforeLockWindow);
 
         // Within lock window, values from previous update would be returned.
-        (latestAnswer, latestTimestamp,) = oval.internalLatestData();
+        (latestAnswer, latestTimestamp, latestRoundId) = oval.internalLatestData();
         assertTrue(latestAnswer == newAnswer && latestTimestamp == beforeLockWindow);
+        assertTrue(latestRoundId == latestPublishedRound - 1);
     }
 }

--- a/test/unit/adapters/BoundedUnionSource.SelectBoundedPrice.sol
+++ b/test/unit/adapters/BoundedUnionSource.SelectBoundedPrice.sol
@@ -31,7 +31,9 @@ contract TestBoundedUnionSource is BoundedUnionSourceAdapter {
         return _withinTolerance(a, b);
     }
 
-    function internalLatestData() public view override returns (int256, uint256) {}
+    function internalLatestData() public view override returns (int256, uint256, uint256) {}
+
+    function internalDataAtRound(uint256 roundId) public view override returns (int256, uint256) {}
 
     function canUnlock(address caller, uint256 cachedLatestTimestamp) public view virtual override returns (bool) {}
 


### PR DESCRIPTION
The current chainlink source adapter does not pass through roundId, and we have some users who would like Oval to more purely reflect the chainlink data when used with a Chainlink destination adapter.

This PR adds following features to support Chainlink roundId:
- When using Chainlink source and destination adapters, roundId is passed through in `latestRoundData`. If paired with other source adapter that does not have concept of rounds, this would still return hardcoded roundId of 1, same as before.
- Exposes `getRoundData` for Chainlink destination adapter. When paired with Chainlink source adapter this would return the requested round data only if its timestamp is not within the effective unlock period. Otherwise it returns uninitialized data, as if requested round has not been yet available - this is consistent with behavior how Chainlink contracts work, so clients should be ready to handle uninitialized values. When paired with other source adapter that does not have a concept of rounds, `getRoundData` would always return uninitialized answer and timestamp values.

Fixes: https://linear.app/uma/issue/UMA-2590/pure-chainlink-adapter