### PR TITLE
fix: remove duplicate decimal scaling in uniswap anchored view source

### DIFF
--- a/src/adapters/source-adapters/UniswapAnchoredViewSourceAdapter.sol
+++ b/src/adapters/source-adapters/UniswapAnchoredViewSourceAdapter.sol
@@ -74,6 +74,6 @@ abstract contract UniswapAnchoredViewSourceAdapter is SnapshotSource {
      */
     function tryLatestDataAt(uint256 timestamp, uint256 maxTraversal) public view override returns (int256, uint256) {
         Snapshot memory snapshot = _tryLatestDataAt(timestamp, maxTraversal);
-        return (DecimalLib.convertDecimals(snapshot.answer, SOURCE_DECIMALS, 18), snapshot.timestamp);
+        return (snapshot.answer, snapshot.timestamp);
     }
 }


### PR DESCRIPTION
`UniswapAnchoredViewSourceAdapter` incorectly applied decimal scaling in its `tryLatestDataAt` method. Internal call to `SnapshotSource._tryLatestDataAt` already applies scaling when fetching latest data via `getLatestSourceData`, so no need to re-apply it.
