### PR TITLE
feat: add maxAge parameter to limit the staleness of a historical data point

### DIFF
--- a/src/DiamondRootOval.sol
+++ b/src/DiamondRootOval.sol
@@ -75,13 +75,16 @@ abstract contract DiamondRootOval is IBaseController, IOval, IBaseOracleAdapter 
      * @notice Time window that bounds how long the permissioned actor has to call the unlockLatestValue function after
      * a new source update is posted. If the permissioned actor does not call unlockLatestValue within this window of a
      * new source price, the latest value will be made available to everyone without going through an MEV-Share auction.
-     * @return lockWindow time in seconds.
      */
     function lockWindow() public view virtual returns (uint256);
 
     /**
      * @notice Max number of historical source updates to traverse when looking for a historic value in the past.
-     * @return maxTraversal max number of historical source updates to traverse.
      */
     function maxTraversal() public view virtual returns (uint256);
+
+    /**
+     * @notice Max age of a historical price that can be used instead of the current price.
+     */
+    function maxAge() public view virtual returns (uint256);
 }

--- a/src/adapters/source-adapters/ChainlinkSourceAdapter.sol
+++ b/src/adapters/source-adapters/ChainlinkSourceAdapter.sol
@@ -94,7 +94,9 @@ abstract contract ChainlinkSourceAdapter is DiamondRootOval {
             _searchRoundDataAt(timestamp, roundId, maxTraversal);
 
         // Validate returned data. If it is uninitialized we fallback to returning the current latest round data.
-        if (historicalUpdatedAt > 0) return (historicalAnswer, historicalUpdatedAt, historicalRoundId);
+        if (historicalUpdatedAt > block.timestamp - maxAge()) {
+            return (historicalAnswer, historicalUpdatedAt, historicalRoundId);
+        }
         return (answer, updatedAt, roundId);
     }
 

--- a/src/adapters/source-adapters/SnapshotSource.sol
+++ b/src/adapters/source-adapters/SnapshotSource.sol
@@ -56,7 +56,7 @@ abstract contract SnapshotSource is DiamondRootOval {
         Snapshot memory historicalData = _searchSnapshotAt(timestamp, maxTraversal);
 
         // Validate returned data. If it is uninitialized or too old we fallback to returning the current latest round data.
-        if (historicalData.timestamp > block.timestamp - maxAge()) return historicalData;
+        if (historicalData.timestamp >= block.timestamp - maxAge()) return historicalData;
         return latestData;
     }
 

--- a/src/adapters/source-adapters/SnapshotSource.sol
+++ b/src/adapters/source-adapters/SnapshotSource.sol
@@ -55,8 +55,8 @@ abstract contract SnapshotSource is DiamondRootOval {
         // Attempt traversing historical snapshot data. This might still be newer or uninitialized.
         Snapshot memory historicalData = _searchSnapshotAt(timestamp, maxTraversal);
 
-        // Validate returned data. If it is uninitialized we fallback to returning the current latest round data.
-        if (historicalData.timestamp > 0) return historicalData;
+        // Validate returned data. If it is uninitialized or too old we fallback to returning the current latest round data.
+        if (historicalData.timestamp > block.timestamp - maxAge()) return historicalData;
         return latestData;
     }
 

--- a/src/controllers/BaseController.sol
+++ b/src/controllers/BaseController.sol
@@ -12,6 +12,7 @@ abstract contract BaseController is Ownable, Oval {
     // these don't need to be public since they can be accessed via the accessor functions below.
     uint256 private lockWindow_ = 60; // The lockWindow in seconds.
     uint256 private maxTraversal_ = 10; // The maximum number of rounds to traverse when looking for historical data.
+    uint256 private maxAge_ = 86400; // Default 1 day.
 
     mapping(address => bool) public unlockers;
 
@@ -67,6 +68,16 @@ abstract contract BaseController is Ownable, Oval {
     }
 
     /**
+     * @notice Enables the owner to set the maxAge.
+     * @param newMaxAge The maxAge to set
+     */
+    function setMaxAge(uint256 newMaxAge) public onlyOwner {
+        maxAge_ = newMaxAge;
+
+        emit MaxAgeSet(newMaxAge);
+    }
+
+    /**
      * @notice Time window that bounds how long the permissioned actor has to call the unlockLatestValue function after
      * a new source update is posted. If the permissioned actor does not call unlockLatestValue within this window of a
      * new source price, the latest value will be made available to everyone without going through an MEV-Share auction.
@@ -81,6 +92,13 @@ abstract contract BaseController is Ownable, Oval {
      * @return maxTraversal max number of historical source updates to traverse.
      */
     function maxTraversal() public view override returns (uint256) {
+        return maxTraversal_;
+    }
+
+    /**
+     * @notice Max age of a historical price that can be used instead of the current price.
+     */
+    function maxAge() public view override returns (uint256) {
         return maxTraversal_;
     }
 }

--- a/src/controllers/BaseController.sol
+++ b/src/controllers/BaseController.sol
@@ -12,7 +12,7 @@ abstract contract BaseController is Ownable, Oval {
     // these don't need to be public since they can be accessed via the accessor functions below.
     uint256 private lockWindow_ = 60; // The lockWindow in seconds.
     uint256 private maxTraversal_ = 10; // The maximum number of rounds to traverse when looking for historical data.
-    uint256 private maxAge_ = 86400; // Default 1 day.
+    uint256 private maxAge_ = 1 days; // Default 1 day.
 
     mapping(address => bool) public unlockers;
 
@@ -99,6 +99,6 @@ abstract contract BaseController is Ownable, Oval {
      * @notice Max age of a historical price that can be used instead of the current price.
      */
     function maxAge() public view override returns (uint256) {
-        return maxTraversal_;
+        return maxAge_;
     }
 }

--- a/src/controllers/ImmutableController.sol
+++ b/src/controllers/ImmutableController.sol
@@ -13,12 +13,14 @@ import {Oval} from "../Oval.sol";
 abstract contract ImmutableController is Oval {
     uint256 private immutable LOCK_WINDOW; // The lockWindow in seconds.
     uint256 private immutable MAX_TRAVERSAL; // The maximum number of rounds to traverse when looking for historical data.
+    uint256 private immutable MAX_AGE;
 
     mapping(address => bool) public unlockers;
 
-    constructor(uint256 _lockWindow, uint256 _maxTraversal, address[] memory _unlockers) {
+    constructor(uint256 _lockWindow, uint256 _maxTraversal, address[] memory _unlockers, uint256 _maxAge) {
         LOCK_WINDOW = _lockWindow;
         MAX_TRAVERSAL = _maxTraversal;
+        MAX_AGE = _maxAge;
         for (uint256 i = 0; i < _unlockers.length; i++) {
             unlockers[_unlockers[i]] = true;
 
@@ -27,6 +29,7 @@ abstract contract ImmutableController is Oval {
 
         emit LockWindowSet(_lockWindow);
         emit MaxTraversalSet(_maxTraversal);
+        emit MaxAgeSet(_maxAge);
     }
 
     /**
@@ -56,5 +59,12 @@ abstract contract ImmutableController is Oval {
      */
     function maxTraversal() public view override returns (uint256) {
         return MAX_TRAVERSAL;
+    }
+
+    /**
+     * @notice Max age of a historical price that can be used instead of the current price.
+     */
+    function maxAge() public view override returns (uint256) {
+        return MAX_AGE;
     }
 }

--- a/src/interfaces/IBaseController.sol
+++ b/src/interfaces/IBaseController.sol
@@ -5,6 +5,7 @@ interface IBaseController {
     event LockWindowSet(uint256 indexed lockWindow);
     event MaxTraversalSet(uint256 indexed maxTraversal);
     event UnlockerSet(address indexed unlocker, bool indexed allowed);
+    event MaxAgeSet(uint256 indexed newMaxAge);
 
     function canUnlock(address caller, uint256 cachedLatestTimestamp) external view returns (bool);
 }

--- a/test/fork/aave/AaveV2.Liquidation.sol
+++ b/test/fork/aave/AaveV2.Liquidation.sol
@@ -20,7 +20,7 @@ interface Usdc is IERC20 {
 contract TestedOval is ImmutableController, ChainlinkSourceAdapter, ChainlinkDestinationAdapter {
     constructor(IAggregatorV3Source source, uint8 decimals, address[] memory unlockers)
         ChainlinkSourceAdapter(source)
-        ImmutableController(60, 10, unlockers)
+        ImmutableController(60, 10, unlockers, 86400)
         ChainlinkDestinationAdapter(decimals)
     {}
 }

--- a/test/fork/aave/AaveV3.Liquidation.sol
+++ b/test/fork/aave/AaveV3.Liquidation.sol
@@ -20,7 +20,7 @@ interface Usdc is IERC20 {
 contract TestedOval is ImmutableController, ChainlinkSourceAdapter, ChainlinkDestinationAdapter {
     constructor(IAggregatorV3Source source, uint8 decimals, address[] memory unlockers)
         ChainlinkSourceAdapter(source)
-        ImmutableController(60, 10, unlockers)
+        ImmutableController(60, 10, unlockers, 86400)
         ChainlinkDestinationAdapter(decimals)
     {}
 }

--- a/test/fork/adapters/ChainlinkSourceAdapter.sol
+++ b/test/fork/adapters/ChainlinkSourceAdapter.sol
@@ -20,6 +20,8 @@ contract TestedSourceAdapter is ChainlinkSourceAdapter {
     function lockWindow() public view virtual override returns (uint256) {}
 
     function maxTraversal() public view virtual override returns (uint256) {}
+
+    function maxAge() public view virtual override returns (uint256) {}
 }
 
 contract ChainlinkSourceAdapterTest is CommonTest {

--- a/test/fork/adapters/ChainlinkSourceAdapter.sol
+++ b/test/fork/adapters/ChainlinkSourceAdapter.sol
@@ -8,20 +8,8 @@ import {ChainlinkSourceAdapter} from "../../../src/adapters/source-adapters/Chai
 import {DecimalLib} from "../../../src/adapters/lib/DecimalLib.sol";
 import {IAggregatorV3Source} from "../../../src/interfaces/chainlink/IAggregatorV3Source.sol";
 
-contract TestedSourceAdapter is ChainlinkSourceAdapter {
+contract TestedSourceAdapter is ChainlinkSourceAdapter, BaseController {
     constructor(IAggregatorV3Source source) ChainlinkSourceAdapter(source) {}
-
-    function internalLatestData() public view override returns (int256, uint256, uint256) {}
-
-    function internalDataAtRound(uint256 roundId) public view override returns (int256, uint256) {}
-
-    function canUnlock(address caller, uint256 cachedLatestTimestamp) public view virtual override returns (bool) {}
-
-    function lockWindow() public view virtual override returns (uint256) {}
-
-    function maxTraversal() public view virtual override returns (uint256) {}
-
-    function maxAge() public view virtual override returns (uint256) {}
 }
 
 contract ChainlinkSourceAdapterTest is CommonTest {

--- a/test/fork/adapters/ChainlinkSourceAdapter.sol
+++ b/test/fork/adapters/ChainlinkSourceAdapter.sol
@@ -97,6 +97,33 @@ contract ChainlinkSourceAdapterTest is CommonTest {
         assertTrue(uint256(roundId) == lookBackRoundId);
     }
 
+    function testCorrectlyBoundsMaxLooBackByMaxAge() public {
+        // Value returned at 2 days should be the same as the value returned at 1 day as the max age is 1 day.
+        assertTrue(sourceAdapter.maxAge() == 1 days);
+        (int256 lookBackPricePastWindow, uint256 lookBackTimestampPastWindow, uint256 lookBackRoundIdPastWindow) =
+            sourceAdapter.tryLatestDataAt(block.timestamp - 2 days, 50);
+
+        (int256 lookBackPriceAtLimit, uint256 lookBackTimestampAtLimit, uint256 lookBackRoundIdAtLimit) =
+            sourceAdapter.tryLatestDataAt(block.timestamp - 1 days, 50);
+
+        assertTrue(lookBackPricePastWindow == lookBackPriceAtLimit);
+        assertTrue(lookBackTimestampPastWindow == lookBackTimestampAtLimit);
+        assertTrue(lookBackRoundIdPastWindow == lookBackRoundIdAtLimit);
+    }
+
+    function testExtendingMaxAgeCorrectlyExtendsWindowOfReturnedValue() public {
+        sourceAdapter.setMaxAge(2 days);
+        (int256 lookBackPricePastWindow, uint256 lookBackTimestampPastWindow, uint256 lookBackRoundIdPastWindow) =
+            sourceAdapter.tryLatestDataAt(block.timestamp - 3 days, 50);
+
+        (int256 lookBackPriceAtLimit, uint256 lookBackTimestampAtLimit, uint256 lookBackRoundIdAtLimit) =
+            sourceAdapter.tryLatestDataAt(block.timestamp - 2 days, 50);
+
+        assertTrue(lookBackPricePastWindow == lookBackPriceAtLimit);
+        assertTrue(lookBackTimestampPastWindow == lookBackTimestampAtLimit);
+        assertTrue(lookBackRoundIdPastWindow == lookBackRoundIdAtLimit);
+    }
+
     function testNonHistoricalData() public {
         uint256 targetTime = block.timestamp - 1 hours;
 

--- a/test/fork/adapters/ChronicleMedianSourceAdapter.sol
+++ b/test/fork/adapters/ChronicleMedianSourceAdapter.sol
@@ -3,17 +3,12 @@ pragma solidity 0.8.17;
 
 import {CommonTest} from "../../Common.sol";
 
+import {BaseController} from "../../../src/controllers/BaseController.sol";
 import {ChronicleMedianSourceAdapter} from "../../../src/adapters/source-adapters/ChronicleMedianSourceAdapter.sol";
 import {IMedian} from "../../../src/interfaces/chronicle/IMedian.sol";
 
-contract TestedSourceAdapter is ChronicleMedianSourceAdapter {
+contract TestedSourceAdapter is ChronicleMedianSourceAdapter, BaseController {
     constructor(IMedian source) ChronicleMedianSourceAdapter(source) {}
-    function internalLatestData() public view override returns (int256, uint256, uint256) {}
-    function internalDataAtRound(uint256 roundId) public view override returns (int256, uint256) {}
-    function canUnlock(address caller, uint256 cachedLatestTimestamp) public view virtual override returns (bool) {}
-    function lockWindow() public view virtual override returns (uint256) {}
-    function maxTraversal() public view virtual override returns (uint256) {}
-    function maxAge() public view virtual override returns (uint256) {}
 }
 
 contract ChronicleMedianSourceAdapterTest is CommonTest {

--- a/test/fork/adapters/ChronicleMedianSourceAdapter.sol
+++ b/test/fork/adapters/ChronicleMedianSourceAdapter.sol
@@ -13,6 +13,7 @@ contract TestedSourceAdapter is ChronicleMedianSourceAdapter {
     function canUnlock(address caller, uint256 cachedLatestTimestamp) public view virtual override returns (bool) {}
     function lockWindow() public view virtual override returns (uint256) {}
     function maxTraversal() public view virtual override returns (uint256) {}
+    function maxAge() public view virtual override returns (uint256) {}
 }
 
 contract ChronicleMedianSourceAdapterTest is CommonTest {

--- a/test/fork/adapters/OSMSourceAdapter.sol
+++ b/test/fork/adapters/OSMSourceAdapter.sol
@@ -3,18 +3,13 @@ pragma solidity 0.8.17;
 
 import {CommonTest} from "../../Common.sol";
 
+import {BaseController} from "../../../src/controllers/BaseController.sol";
 import {OSMSourceAdapter} from "../../../src/adapters/source-adapters/OSMSourceAdapter.sol";
 import {IOSM} from "../../../src/interfaces/makerdao/IOSM.sol";
 import {IMedian} from "../../../src/interfaces/chronicle/IMedian.sol";
 
-contract TestedSourceAdapter is OSMSourceAdapter {
+contract TestedSourceAdapter is OSMSourceAdapter, BaseController {
     constructor(IOSM source) OSMSourceAdapter(source) {}
-    function internalLatestData() public view override returns (int256, uint256, uint256) {}
-    function internalDataAtRound(uint256 roundId) public view override returns (int256, uint256) {}
-    function canUnlock(address caller, uint256 cachedLatestTimestamp) public view virtual override returns (bool) {}
-    function lockWindow() public view virtual override returns (uint256) {}
-    function maxTraversal() public view virtual override returns (uint256) {}
-    function maxAge() public view virtual override returns (uint256) {}
 }
 
 contract OSMSourceAdapterTest is CommonTest {

--- a/test/fork/adapters/OSMSourceAdapter.sol
+++ b/test/fork/adapters/OSMSourceAdapter.sol
@@ -14,6 +14,7 @@ contract TestedSourceAdapter is OSMSourceAdapter {
     function canUnlock(address caller, uint256 cachedLatestTimestamp) public view virtual override returns (bool) {}
     function lockWindow() public view virtual override returns (uint256) {}
     function maxTraversal() public view virtual override returns (uint256) {}
+    function maxAge() public view virtual override returns (uint256) {}
 }
 
 contract OSMSourceAdapterTest is CommonTest {

--- a/test/fork/adapters/PythSourceAdapter.sol
+++ b/test/fork/adapters/PythSourceAdapter.sol
@@ -18,6 +18,8 @@ contract TestedSourceAdapter is PythSourceAdapter {
     function lockWindow() public view virtual override returns (uint256) {}
 
     function maxTraversal() public view virtual override returns (uint256) {}
+
+    function maxAge() public view virtual override returns (uint256) {}
 }
 
 contract PythSourceAdapterTest is CommonTest {

--- a/test/fork/adapters/PythSourceAdapter.sol
+++ b/test/fork/adapters/PythSourceAdapter.sol
@@ -3,23 +3,12 @@ pragma solidity 0.8.17;
 
 import {CommonTest} from "../../Common.sol";
 
+import {BaseController} from "../../../src/controllers/BaseController.sol";
 import {PythSourceAdapter} from "../../../src/adapters/source-adapters/PythSourceAdapter.sol";
 import {IPyth} from "../../../src/interfaces/pyth/IPyth.sol";
 
-contract TestedSourceAdapter is PythSourceAdapter {
+contract TestedSourceAdapter is PythSourceAdapter, BaseController {
     constructor(IPyth source, bytes32 priceId) PythSourceAdapter(source, priceId) {}
-
-    function internalLatestData() public view override returns (int256, uint256, uint256) {}
-
-    function internalDataAtRound(uint256 roundId) public view override returns (int256, uint256) {}
-
-    function canUnlock(address caller, uint256 cachedLatestTimestamp) public view virtual override returns (bool) {}
-
-    function lockWindow() public view virtual override returns (uint256) {}
-
-    function maxTraversal() public view virtual override returns (uint256) {}
-
-    function maxAge() public view virtual override returns (uint256) {}
 }
 
 contract PythSourceAdapterTest is CommonTest {

--- a/test/fork/adapters/UnionSourceAdapter.sol
+++ b/test/fork/adapters/UnionSourceAdapter.sol
@@ -2,28 +2,18 @@
 pragma solidity 0.8.17;
 
 import {CommonTest} from "../../Common.sol";
+
+import {BaseController} from "../../../src/controllers/BaseController.sol";
 import {UnionSourceAdapter} from "../../../src/adapters/source-adapters/UnionSourceAdapter.sol";
 import {IAggregatorV3Source} from "../../../src/interfaces/chainlink/IAggregatorV3Source.sol";
 import {IMedian} from "../../../src/interfaces/chronicle/IMedian.sol";
 import {IPyth} from "../../../src/interfaces/pyth/IPyth.sol";
 import {DecimalLib} from "../../../src/adapters/lib/DecimalLib.sol";
 
-contract TestedSourceAdapter is UnionSourceAdapter {
+contract TestedSourceAdapter is UnionSourceAdapter, BaseController {
     constructor(IAggregatorV3Source chainlink, IMedian chronicle, IPyth pyth, bytes32 pythPriceId)
         UnionSourceAdapter(chainlink, chronicle, pyth, pythPriceId)
     {}
-
-    function internalLatestData() public view override returns (int256, uint256, uint256) {}
-
-    function internalDataAtRound(uint256 roundId) public view override returns (int256, uint256) {}
-
-    function canUnlock(address caller, uint256 cachedLatestTimestamp) public view virtual override returns (bool) {}
-
-    function lockWindow() public view virtual override returns (uint256) {}
-
-    function maxTraversal() public view virtual override returns (uint256) {}
-
-    function maxAge() public view virtual override returns (uint256) {}
 }
 
 contract UnionSourceAdapterTest is CommonTest {
@@ -176,6 +166,7 @@ contract UnionSourceAdapterTest is CommonTest {
         // Fork to a block where chronicle was the newest.
         vm.createSelectFork("mainnet", targetChronicleBlock);
         uint256 targetTimestamp = block.timestamp;
+        sourceAdapter.setMaxAge(2 days); // Set max age to 2 days to disable this logic for the test.
         _whitelistOnChronicle();
 
         // Snapshotting union adapter should not affect historical lookups, but we do it just to prove it does not interfere.

--- a/test/fork/adapters/UnionSourceAdapter.sol
+++ b/test/fork/adapters/UnionSourceAdapter.sol
@@ -22,6 +22,8 @@ contract TestedSourceAdapter is UnionSourceAdapter {
     function lockWindow() public view virtual override returns (uint256) {}
 
     function maxTraversal() public view virtual override returns (uint256) {}
+
+    function maxAge() public view virtual override returns (uint256) {}
 }
 
 contract UnionSourceAdapterTest is CommonTest {

--- a/test/fork/adapters/UniswapAnchoredViewSourceAdapter.sol
+++ b/test/fork/adapters/UniswapAnchoredViewSourceAdapter.sol
@@ -17,6 +17,7 @@ contract TestedSourceAdapter is UniswapAnchoredViewSourceAdapter {
     function canUnlock(address caller, uint256 cachedLatestTimestamp) public view virtual override returns (bool) {}
     function lockWindow() public view virtual override returns (uint256) {}
     function maxTraversal() public view virtual override returns (uint256) {}
+    function maxAge() public view virtual override returns (uint256) {}
 }
 
 contract UniswapAnchoredViewSourceAdapterTest is CommonTest {

--- a/test/fork/adapters/UniswapAnchoredViewSourceAdapter.sol
+++ b/test/fork/adapters/UniswapAnchoredViewSourceAdapter.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.17;
 
 import {CommonTest} from "../../Common.sol";
 
+import {BaseController} from "../../../src/controllers/BaseController.sol";
 import {IValidatorProxyTest} from "../interfaces/compoundV2/IValidatorProxy.sol";
 import {MockChainlinkV3Aggregator} from "../../mocks/MockChainlinkV3Aggregator.sol";
 import {UniswapAnchoredViewSourceAdapter} from
@@ -10,14 +11,8 @@ import {UniswapAnchoredViewSourceAdapter} from
 import {IAccessControlledAggregatorV3} from "../../../src/interfaces/chainlink/IAccessControlledAggregatorV3.sol";
 import {IUniswapAnchoredView} from "../../../src/interfaces/compound/IUniswapAnchoredView.sol";
 
-contract TestedSourceAdapter is UniswapAnchoredViewSourceAdapter {
+contract TestedSourceAdapter is UniswapAnchoredViewSourceAdapter, BaseController {
     constructor(IUniswapAnchoredView source, address cToken) UniswapAnchoredViewSourceAdapter(source, cToken) {}
-    function internalLatestData() public view override returns (int256, uint256, uint256) {}
-    function internalDataAtRound(uint256 roundId) public view override returns (int256, uint256) {}
-    function canUnlock(address caller, uint256 cachedLatestTimestamp) public view virtual override returns (bool) {}
-    function lockWindow() public view virtual override returns (uint256) {}
-    function maxTraversal() public view virtual override returns (uint256) {}
-    function maxAge() public view virtual override returns (uint256) {}
 }
 
 contract UniswapAnchoredViewSourceAdapterTest is CommonTest {

--- a/test/fork/compound/CompoundV2.Liquidation.sol
+++ b/test/fork/compound/CompoundV2.Liquidation.sol
@@ -27,7 +27,7 @@ interface Usdc is IERC20 {
 contract TestedOval is ImmutableController, UniswapAnchoredViewSourceAdapter, BaseDestinationAdapter {
     constructor(IUniswapAnchoredView source, address cToken, address[] memory unlockers)
         UniswapAnchoredViewSourceAdapter(source, cToken)
-        ImmutableController(60, 10, unlockers)
+        ImmutableController(60, 10, unlockers, 86400)
         BaseDestinationAdapter()
     {}
 }

--- a/test/unit/BaseController.sol
+++ b/test/unit/BaseController.sol
@@ -65,4 +65,17 @@ contract OvalUnlockLatestValue is CommonTest {
         vm.expectRevert("Ownable: caller is not the owner");
         baseController.setMaxTraversal(100);
     }
+
+    function testOwnerCanSetMaxAge() public {
+        uint256 newMaxAge = 7200; // 2 hours in seconds, different from default 1 day
+        vm.prank(owner);
+        baseController.setMaxAge(newMaxAge);
+        assertTrue(baseController.maxAge() == newMaxAge);
+    }
+
+    function testNonOwnerCannotSetMaxAge() public {
+        vm.prank(random);
+        vm.expectRevert("Ownable: caller is not the owner");
+        baseController.setMaxAge(7200);
+    }
 }

--- a/test/unit/ImmutableController.sol
+++ b/test/unit/ImmutableController.sol
@@ -7,9 +7,15 @@ import {BaseDestinationAdapter} from "../../src/adapters/destination-adapters/Ba
 import {MockSourceAdapter} from "../mocks/MockSourceAdapter.sol";
 
 contract TestImmutableController is ImmutableController, MockSourceAdapter, BaseDestinationAdapter {
-    constructor(uint8 decimals, uint256 _lockWindow, uint256 _maxTraversal, address[] memory _unlockers)
+    constructor(
+        uint8 decimals,
+        uint256 _lockWindow,
+        uint256 _maxTraversal,
+        address[] memory _unlockers,
+        uint256 _maxAge
+    )
         MockSourceAdapter(decimals)
-        ImmutableController(_lockWindow, _maxTraversal, _unlockers)
+        ImmutableController(_lockWindow, _maxTraversal, _unlockers, _maxAge)
         BaseDestinationAdapter()
     {}
 }
@@ -19,6 +25,7 @@ contract OvalUnlockLatestValue is CommonTest {
     uint256 lockWindow = 60;
     uint256 maxTraversal = 10;
     address[] unlockers;
+    uint256 maxAge = 86400;
 
     uint256 lastUnlockTime = 1690000000;
 
@@ -28,7 +35,7 @@ contract OvalUnlockLatestValue is CommonTest {
         unlockers.push(permissionedUnlocker);
 
         vm.startPrank(owner);
-        immutableController = new TestImmutableController(decimals, lockWindow, maxTraversal, unlockers);
+        immutableController = new TestImmutableController(decimals, lockWindow, maxTraversal, unlockers, maxAge);
         vm.stopPrank();
     }
 

--- a/test/unit/adapters/BoundedUnionSource.SelectBoundedPrice.sol
+++ b/test/unit/adapters/BoundedUnionSource.SelectBoundedPrice.sol
@@ -39,6 +39,7 @@ contract TestBoundedUnionSource is BoundedUnionSourceAdapter {
 
     function lockWindow() public view virtual override returns (uint256) {}
     function maxTraversal() public view virtual override returns (uint256) {}
+    function maxAge() public view virtual override returns (uint256) {}
 }
 
 contract MinimalChainlinkAdapter {


### PR DESCRIPTION
One Oval-related trust vector has surfaced recently. If the oracle is not responsible for keeping snapshots, then someone else is. If that entity allows snapshots to become sufficiently stale, it can lead to the application using very stale prices when a new price comes in.

One idea was to add a maxAge that limits how stale a historical snapshot can be before the current data is used instead.

Note: this PR is an example of how this would work. Tests need to be fixed and added.