### PR TITLE
M-03 [Oval] Newest Prices May Be Reported Ignoring the lockWindow() Constraint

### DIFF
--- a/src/controllers/ImmutableController.sol
+++ b/src/controllers/ImmutableController.sol
@@ -18,6 +18,9 @@ abstract contract ImmutableController is Oval {
     mapping(address => bool) public unlockers;
 
     constructor(uint256 _lockWindow, uint256 _maxTraversal, address[] memory _unlockers, uint256 _maxAge) {
+        require(_maxAge > _lockWindow, "Max age not above lock window");
+        require(_maxTraversal > 0, "Max traversal must be > 0");
+
         LOCK_WINDOW = _lockWindow;
         MAX_TRAVERSAL = _maxTraversal;
         MAX_AGE = _maxAge;

--- a/src/controllers/MutableUnlockersController.sol
+++ b/src/controllers/MutableUnlockersController.sol
@@ -16,6 +16,9 @@ abstract contract MutableUnlockersController is Ownable, Oval {
     mapping(address => bool) public unlockers;
 
     constructor(uint256 _lockWindow, uint256 _maxTraversal, address[] memory _unlockers, uint256 _maxAge) {
+        require(_maxAge > _lockWindow, "Max age not above lock window");
+        require(_maxTraversal > 0, "Max traversal must be > 0");
+
         LOCK_WINDOW = _lockWindow;
         MAX_TRAVERSAL = _maxTraversal;
         MAX_AGE = _maxAge;

--- a/src/factories/BaseFactory.sol
+++ b/src/factories/BaseFactory.sol
@@ -24,6 +24,8 @@ contract BaseFactory is Ownable {
     );
 
     constructor(uint256 _maxTraversal, address[] memory _defaultUnlockers) {
+        require(_maxTraversal > 0, "Max traversal must be > 0");
+
         MAX_TRAVERSAL = _maxTraversal;
         setDefaultUnlockers(_defaultUnlockers);
     }


### PR DESCRIPTION
Addresses audit issue: M-03 [Oval] Newest Prices May Be Reported Ignoring the lockWindow() Constraint

```
The _tryLatestRoundDataAt function is invoked after the tryLatestDataAt function is
called inside the internalLatestData function of the Oval contract. Its timestamp
argument is equal to the maximum of the last unlock time and block.timestamp -
lockWindow() . Before the introduction of the maxAge() parameter, it used to be that in
cases where the price data had been unlocked inside the lockWindow() period, the price
data would be returned. In the opposite case, the most recent price as of block.timestamp
- lockWindow() timestamp would be returned.

Now, the maxAge() parameter has been introduced to limit the staleness of the data returned
by the adapters. If the data to be returned by the _tryLatestRoundDataAt function is older
than the maxAge() , the most recent price data is returned instead. This means that if the
maxAge() is lower than the lockWindow() and the last price is unlocked within the
lockWindow() , but its timestamp is older than the maxAge() parameter, the newest price
will be returned by the internalLatestData function of the Oval contract.

However, this is not the desired behavior as the lock window mechanism has been introduced
in order to guarantee that the "unlock" transactions unlock the most recent price that has not
yet been used by anyone. As a consequence, the OEV opportunity for Oval will be lost since
the newest price will be available for use by anyone before the "unlock" transaction takes
place. A similar scenario may happen if the maxTraversal parameter is set to 0. In such a
case, uninitialized data is returned by the _searchRoundDataAt functions inside the
adapters and hence the check against the maxAge() value will never pass. As a result, the
newest price data will always be returned.

Consider carefully validating the parameters with which the Oval contracts are deployed,
especially ensuring that the max age is always bigger than the lock window and that the
maxTraversal parameter is set to a reasonable value.
```

This implements the recommended fix by validating Oval controller constructor parameters.