### PR TITLE
fix[oval-audit-m-04]: validate base controller parameters

### DIFF
--- a/src/controllers/BaseController.sol
+++ b/src/controllers/BaseController.sol
@@ -46,13 +46,13 @@ abstract contract BaseController is Ownable, Oval {
      * @param newLockWindow The lockWindow to set.
      */
     function setLockWindow(uint256 newLockWindow) public onlyOwner {
+        require(maxAge() > newLockWindow, "Max age not above lock window");
+
         (int256 currentAnswer, uint256 currentTimestamp,) = internalLatestData();
 
         lockWindow_ = newLockWindow;
 
-        // Compare Oval results so that change in lock window does not change returned data.
-        (int256 newAnswer, uint256 newTimestamp,) = internalLatestData();
-        require(currentAnswer == newAnswer && currentTimestamp == newTimestamp, "Must unlock first");
+        _checkDataNotChanged(currentAnswer, currentTimestamp);
 
         emit LockWindowSet(newLockWindow);
     }
@@ -62,7 +62,13 @@ abstract contract BaseController is Ownable, Oval {
      * @param newMaxTraversal The maxTraversal to set.
      */
     function setMaxTraversal(uint256 newMaxTraversal) public onlyOwner {
+        require(newMaxTraversal > 0, "Max traversal must be > 0");
+
+        (int256 currentAnswer, uint256 currentTimestamp,) = internalLatestData();
+
         maxTraversal_ = newMaxTraversal;
+
+        _checkDataNotChanged(currentAnswer, currentTimestamp);
 
         emit MaxTraversalSet(newMaxTraversal);
     }
@@ -72,7 +78,13 @@ abstract contract BaseController is Ownable, Oval {
      * @param newMaxAge The maxAge to set
      */
     function setMaxAge(uint256 newMaxAge) public onlyOwner {
+        require(newMaxAge > lockWindow(), "Max age not above lock window");
+
+        (int256 currentAnswer, uint256 currentTimestamp,) = internalLatestData();
+
         maxAge_ = newMaxAge;
+
+        _checkDataNotChanged(currentAnswer, currentTimestamp);
 
         emit MaxAgeSet(newMaxAge);
     }
@@ -100,5 +112,11 @@ abstract contract BaseController is Ownable, Oval {
      */
     function maxAge() public view override returns (uint256) {
         return maxAge_;
+    }
+
+    // Helper function to ensure that changing controller parameters does not change the returned data.
+    function _checkDataNotChanged(int256 currentAnswer, uint256 currentTimestamp) internal view {
+        (int256 newAnswer, uint256 newTimestamp,) = internalLatestData();
+        require(currentAnswer == newAnswer && currentTimestamp == newTimestamp, "Must unlock first");
     }
 }


### PR DESCRIPTION
Addresses audit issue: M-04 [Oval] Updating Parameters Inside the BaseController Contract May Lead to Undesired Outcomes

```
The maxAge() parameter has been introduced to controllers in order to limit the staleness of
the data returned by the adapters. Stale data could possibly be returned if no "unlock"
transaction happens during the lockWindow() period. In such a case, the latest available
price data for block.timestamp - lockWindow() is returned. The maxAge() parameter
specifies the maximum age of such price data and, in case when the price is too old, the most
recent price data is returned. Inside both ImmutableController and
MutableUnlockersController , the maxAge() parameter is immutable and cannot be
changed, but it is possible to change it inside the BaseController contract.

However, changing this parameter may lead to undesired results. One of the problems which
may happen after such a change arises when the price data from an oracle is not unlocked for
the lockWindow() time and the timestamp of the most recent price older than the
lockWindow() is older than what the maxAge() parameter allows. In such a case, the
newest price data is returned in order to avoid returning too stale prices. However, if
maxAge() is then changed to a higher value, such that the most recent price as of
block.timestamp - lockWindow() is not older than the maxAge() , that older price will
be returned. It means that in the same block, the oracle adapter may return the most recent
data and then the stale data, which is an unexpected and incorrect behavior.

The opposite scenario is also possible when the maxAge() parameter is decreased. In such a
case, the most recent data will be unexpectedly returned which will take away the possibility of
extracting OEV for the newest price for Oval by unlocking the price. It should be noted that
these are just two of many different scenarios that may happen if the maxAge() parameter is
changed. Similar problems may also arise when the unlockWindow() and
maxTraversal() parameters are modified, even if maxAge() stays the same.

Consider setting the maxAge() , unlockWindow() , and maxTraversal() parameters as
immutable inside the BaseController in order to avoid returning multiple different prices for
the same timestamp.
```

This addresses the issue by adding validation checks when changing BaseController parameters.