### PR TITLE
L-05 [Oval] PermissionProxy.execute Will Fail if Non-Zero value Is Provided

### DIFF
--- a/src/factories/PermissionProxy.sol
+++ b/src/factories/PermissionProxy.sol
@@ -12,7 +12,7 @@ import {Multicall} from "openzeppelin-contracts/contracts/utils/Multicall.sol";
  */
 contract PermissionProxy is Ownable, Multicall {
     error SenderNotApproved(address sender);
-    error CallFailed(address target, uint256 value, bytes callData);
+    error CallFailed(address target, bytes callData);
 
     event SenderSet(address sender, bool allowed);
 
@@ -32,20 +32,19 @@ contract PermissionProxy is Ownable, Multicall {
      * @notice Executes a call from this contract.
      * @dev Can only be called by an allowed sender.
      * @param target the address to call.
-     * @param value the value to send.
      * @param callData the calldata to use for the call.
      * @return the data returned by the external call.
      *
      */
-    function execute(address target, uint256 value, bytes memory callData) external returns (bytes memory) {
+    function execute(address target, bytes memory callData) external returns (bytes memory) {
         if (!senders[msg.sender]) {
             revert SenderNotApproved(msg.sender);
         }
 
-        (bool success, bytes memory returnData) = target.call{value: value}(callData);
+        (bool success, bytes memory returnData) = target.call{value: 0}(callData);
 
         if (!success) {
-            revert CallFailed(target, value, callData);
+            revert CallFailed(target, callData);
         }
 
         return returnData;

--- a/test/unit/PermissionProxy.sol
+++ b/test/unit/PermissionProxy.sol
@@ -8,7 +8,6 @@ contract PermissionProxyTest is CommonTest {
     PermissionProxy permissionProxy;
     address mockAddress = address(0xdeadbeef);
     bytes testCallData = abi.encodeWithSignature("foo()");
-    uint256 testValue = 1;
     bytes returnData = abi.encode(uint256(7));
 
     function setUp() public {
@@ -19,22 +18,22 @@ contract PermissionProxyTest is CommonTest {
     function testSenderPermissions() public {
         vm.prank(account2);
         vm.expectRevert(abi.encodeWithSelector(PermissionProxy.SenderNotApproved.selector, account2));
-        permissionProxy.execute(mockAddress, testValue, testCallData);
+        permissionProxy.execute(mockAddress, testCallData);
 
         vm.prank(account1);
-        vm.mockCall(mockAddress, testValue, testCallData, abi.encode(uint256(7)));
-        vm.expectCall(mockAddress, testValue, testCallData);
-        bytes memory actualReturnValue = permissionProxy.execute(mockAddress, testValue, testCallData);
+        vm.mockCall(mockAddress, testCallData, abi.encode(uint256(7)));
+        vm.expectCall(mockAddress, testCallData);
+        bytes memory actualReturnValue = permissionProxy.execute(mockAddress, testCallData);
         assertEq0(actualReturnValue, returnData);
     }
 
     function testCallFailed() public {
         vm.prank(account1);
-        vm.mockCallRevert(mockAddress, testValue, testCallData, "");
+        vm.mockCallRevert(mockAddress, testCallData, "");
         vm.expectRevert(
-            abi.encodeWithSelector(PermissionProxy.CallFailed.selector, mockAddress, testValue, testCallData)
+            abi.encodeWithSelector(PermissionProxy.CallFailed.selector, mockAddress, testCallData)
         );
-        permissionProxy.execute(mockAddress, testValue, testCallData);
+        permissionProxy.execute(mockAddress, testCallData);
     }
 
     function testSetSender() public {


### PR DESCRIPTION
Addresses audit issue: L-05 [Oval] PermissionProxy.execute Will Fail if Non-Zero value Is Provided

```
The PermissionProxy contract is intended to be used as a proxy for calls that unlock new
prices reported as a part of the MEV-share auction flow. It allows multiple different accounts to
unlock new prices by performing calls to the controllers on their behalf. Calls may only be
performed by authorized accounts and may be executed by invoking the execute function.
Apart from the call target and the call data, it is possible to also specify the call value. However,
the PermissionProxy contract has no function allowing it to receive the native value. This
means that it is not possible for users to execute any call involving non-zero native value as all
such calls would revert.

Consider making the execute function payable or removing the value argument if the
PermissionProxy contract is not expected to make any calls with non-zero native value.
```

This implements the recommended fix by removing the value argument from PermissionProxy.