### PR TITLE
L-07 [Oval] Missing Input Validation

### DIFF
--- a/src/oracles/CoinbaseOracle.sol
+++ b/src/oracles/CoinbaseOracle.sol
@@ -28,6 +28,8 @@ contract CoinbaseOracle is IAggregatorV3SourceCoinbase {
      * @param _reporter The address of the reporter allowed to push price data.
      */
     constructor(uint8 _decimals, address _reporter) {
+        require(_reporter != address(0), "Invalid reporter address");
+
         decimals = _decimals;
         reporter = _reporter;
     }


### PR DESCRIPTION
Addresses audit issue: L-07 [Oval] Missing Input Validation

```
The deployer of the CoinbaseOracle contract sets the immutable reporter variable
during the contract's construction. The reporter is the sole entity authorized to submit new
prices to the oracle via the pushPrice function. The access control mechanism in
pushPrice involves recovering the signer of the provided message and verifying that it
matches the reporter's address. However, the ecrecover precompile does not fail on invalid
signatures. Instead, it returns the zero address. If the reporter address is erroneously
configured to the zero address, it becomes trivial for any entity to push arbitrary prices to the
oracle contract.

Consider implementing a validation check to ensure that the reporter address is not set to the
zero address to prevent erroneous contract deployments.
```

This implements the recommended fix by validating CoinbaseOracle constructor parameters.