### PR TITLE
N-10 [Oval] Typographical Errors

### DIFF
--- a/src/controllers/MutableUnlockersController.sol
+++ b/src/controllers/MutableUnlockersController.sol
@@ -5,7 +5,7 @@ import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
 import {Oval} from "../Oval.sol";
 
 /**
- * @title MutableUnlockersController is a controller that only allows unlockers to be change, but other params are immutable.
+ * @title MutableUnlockersController is a controller that only allows unlockers to be changed, but other params are immutable.
  */
 abstract contract MutableUnlockersController is Ownable, Oval {
     // these don't need to be public since they can be accessed via the accessor functions below.

--- a/src/factories/PermissionProxy.sol
+++ b/src/factories/PermissionProxy.sol
@@ -5,9 +5,9 @@ import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
 import {Multicall} from "openzeppelin-contracts/contracts/utils/Multicall.sol";
 
 /**
- * @title PermissionProxy is a proxy that allows extends the permissions given to it to a configurable set
+ * @title PermissionProxy is a proxy that extends the permissions given to it to a configurable set
  * of addresses.
- * @dev The intended use case for this contract is to add this as a single unlocker to oval contracts, allowing the
+ * @dev The intended use case for this contract is to add this as a single unlocker to Oval contracts, allowing the
  * owner of this contract to delegate that permission to many different unlocker addresses.
  */
 contract PermissionProxy is Ownable, Multicall {


### PR DESCRIPTION
Fixes the following issue reported in the Oval Incremental Audit:
```
Throughout the codebase, there are several instances of typographical errors:
In the PermissionProxy.sol file:
In line 8, the word "allows" should be removed.
In line 10, the word "oval" should be written starting with a capital letter.
In the MutableUnlockersController.sol file:
In line 8, "can be change" should be "can be changed".
Consider fixing all instances of typographical errors in order to improve the readability of the
codebase.
```