### PR TITLE
L-06 [Oval] CoinbaseSourceAdapter May Return Old Prices

### DIFF
--- a/src/adapters/source-adapters/CoinbaseSourceAdapter.sol
+++ b/src/adapters/source-adapters/CoinbaseSourceAdapter.sol
@@ -83,8 +83,8 @@ abstract contract CoinbaseSourceAdapter is DiamondRootOval {
         // Attempt traversing historical round data backwards from roundId.
         (int256 historicalAnswer, uint256 historicalUpdatedAt) = _searchRoundDataAt(timestamp, roundId, maxTraversal);
 
-        // Validate returned data. If it is uninitialized, fall back to returning the current latest round data.
-        if (historicalUpdatedAt > 0) {
+        // Validate returned data. If it is uninitialized or too old, fall back to returning the current latest round data.
+        if (historicalUpdatedAt > block.timestamp - maxAge()) {
             return (historicalAnswer, historicalUpdatedAt);
         }
 


### PR DESCRIPTION
Addresses audit issue: L-06 [Oval] CoinbaseSourceAdapter May Return Old Prices

```
In order to limit the staleness of the data returned by source adapters, the maxAge function
has been introduced. It defines the maximum age of prices that can be returned by the
tryLatestDataAt function. However, the CoinbaseSourceAdapter does not use the
maxAge function when it returns historical data as other adapters do. This means that it can
possibly return very old prices.

Consider limiting the staleness of the data returned by the CoinbaseSourceAdapter by
utilizing the maxAge function.
```

This implements the recommended fix by utilizing the maxAge function in CoinbaseSourceAdapter.