### PR TITLE
N-13 [Oval] Misleading Comment

### DIFF
--- a/src/adapters/source-adapters/ChainlinkSourceAdapter.sol
+++ b/src/adapters/source-adapters/ChainlinkSourceAdapter.sol
@@ -93,7 +93,7 @@ abstract contract ChainlinkSourceAdapter is DiamondRootOval {
         (int256 historicalAnswer, uint256 historicalUpdatedAt, uint80 historicalRoundId) =
             _searchRoundDataAt(timestamp, roundId, maxTraversal);
 
-        // Validate returned data. If it is uninitialized we fallback to returning the current latest round data.
+        // Validate returned data. If it is uninitialized or too old, fall back to returning the current latest round data.
         if (historicalUpdatedAt > block.timestamp - maxAge()) {
             return (historicalAnswer, historicalUpdatedAt, historicalRoundId);
         }


### PR DESCRIPTION
Addresses audit issue: N-13 [Oval] Misleading Comment

```
The following misleading comment has been identified:

In ChainlinkSourceAdapter.sol , this comment says that if the data returned by the
_searchRoundDataAt function is uninitialized, the current price data is returned. However,
the latest price data will also be returned in case the _searchRoundDataAt function returns
initialized data that is older than maxAge() .

Consider fixing the comment in order to improve the overall clarity and readability of the
codebase.
```

This implements the recommended fix by elaborating the comment in ChainlinkSourceAdapter.sol.