### PR TITLE
N-14 [Oval] Possible Duplicate Event Emission

### DIFF
--- a/src/controllers/BaseController.sol
+++ b/src/controllers/BaseController.sol
@@ -23,6 +23,8 @@ abstract contract BaseController is Ownable, Oval {
      * @param allowed The unlocker status to set.
      */
     function setUnlocker(address unlocker, bool allowed) public onlyOwner {
+        require(unlockers[unlocker] != allowed, "Unlocker not changed");
+
         unlockers[unlocker] = allowed;
 
         emit UnlockerSet(unlocker, allowed);

--- a/src/controllers/MutableUnlockersController.sol
+++ b/src/controllers/MutableUnlockersController.sol
@@ -36,6 +36,8 @@ abstract contract MutableUnlockersController is Ownable, Oval {
      * @param allowed The unlocker status to set.
      */
     function setUnlocker(address unlocker, bool allowed) public onlyOwner {
+        require(unlockers[unlocker] != allowed, "Unlocker not changed");
+
         unlockers[unlocker] = allowed;
 
         emit UnlockerSet(unlocker, allowed);


### PR DESCRIPTION
Addresses audit issue: N-14 [Oval] Possible Duplicate Event Emission

```
When a setter function does not check if the value has changed, it opens up the possibility of
spamming events indicating that the value has changed when it has not. Spamming the same
values can potentially confuse off-chain clients.

Within MutableUnlockersController.sol , the setUnlocker function sets the
unlockers state variable and emits an event without checking if the value has changed.

Consider adding a check to revert the transaction if the value remains unchanged.
```

This implements the recommended fix by requiring unlockers state to be changed when calling setUnlocker in mutable controllers.